### PR TITLE
Refactor & normalize WelcomeScreen icon links

### DIFF
--- a/src/components/T1Link.tsx
+++ b/src/components/T1Link.tsx
@@ -3,13 +3,13 @@ import { styled, SxProps, Theme } from '@mui/material/styles';
 import { HTMLAttributeAnchorTarget, PropsWithChildren } from 'react';
 import { Link as RouterLink, To } from 'react-router-dom';
 
-export interface ILinkProps extends PropsWithChildren {
+export interface IT1LinkProps extends PropsWithChildren {
   to: To;
   title?: string;
   target?: HTMLAttributeAnchorTarget;
   sx?: SxProps<Theme>;
 }
-export default function Link(props: ILinkProps) {
+export default function T1Link(props: IT1LinkProps) {
   const {
     to,
     sx,

--- a/src/components/home/WelcomeScreen.tsx
+++ b/src/components/home/WelcomeScreen.tsx
@@ -8,7 +8,7 @@ import GitHubIcon from "@mui/icons-material/GitHub";
 import { createSimulateEnv } from "../../utils/setupSimulation";
 import { useRecoilValue } from "recoil";
 import { fileUploadedState } from "../../atoms/fileUploadedState";
-import Link from "../Link";
+import T1Link from "../T1Link";
 import { To } from "react-router-dom";
 
 const Item = styled(Paper)(({theme}) => ({
@@ -101,7 +101,7 @@ export const WelcomeScreen = ({setWasmBuffers, wasmBuffers}: IProps) => {
           lg={6}
           sx={{display: "flex", justifyContent: "center", marginBottom: 4}}
         >
-          <Link to={"/chains"} sx={{textDecoration: "none"}}>
+          <T1Link to={"/chains"} sx={{textDecoration: "none"}}>
             <Button
               variant="contained"
               sx={{borderRadius: "10px"}}
@@ -110,7 +110,7 @@ export const WelcomeScreen = ({setWasmBuffers, wasmBuffers}: IProps) => {
             >
               New Simulation Environment
             </Button>
-          </Link>
+          </T1Link>
         </Grid>
       </Grid>
     </Grid>
@@ -150,7 +150,7 @@ function NavIcon(props: INavIconProps) {
   } = props;
   
   return (
-    <Link {...rest}>
+    <T1Link {...rest}>
       <Grid
         component='div'
         direction='column'
@@ -163,6 +163,6 @@ function NavIcon(props: INavIconProps) {
       >
         {children}
       </Grid>
-    </Link>
+    </T1Link>
   );
 };


### PR DESCRIPTION
Icon links near the top of WelcomeScreen are refactored & normalized into a sub-component.

This PR also introduces a unified custom `Link` class (in `src/components/Link.tsx`) merging & normalizing internal & external links (`Link` from MUI & `Link` from *react-router-dom*)