### PR TITLE
Fixed WelcomeScreen's button navigating when disabled

### DIFF
--- a/src/components/T1Link.tsx
+++ b/src/components/T1Link.tsx
@@ -8,14 +8,19 @@ export interface IT1LinkProps extends PropsWithChildren {
   title?: string;
   target?: HTMLAttributeAnchorTarget;
   sx?: SxProps<Theme>;
+  disabled?: boolean;
 }
 export default function T1Link(props: IT1LinkProps) {
   const {
     to,
     sx,
+    disabled = false,
     ...rest
   } = props;
   
+  if (disabled) {
+    return <>{props.children}</>;
+  }
   if (isExternal(to)) {
     return <ExternalLink href={to} sx={sx} {...rest} />
   }

--- a/src/components/home/WelcomeScreen.tsx
+++ b/src/components/home/WelcomeScreen.tsx
@@ -101,7 +101,7 @@ export const WelcomeScreen = ({setWasmBuffers, wasmBuffers}: IProps) => {
           lg={6}
           sx={{display: "flex", justifyContent: "center", marginBottom: 4}}
         >
-          <T1Link to={"/chains"} sx={{textDecoration: "none"}}>
+          <T1Link to={"/chains"} sx={{textDecoration: "none"}} disabled={!isFileUploaded}>
             <Button
               variant="contained"
               sx={{borderRadius: "10px"}}


### PR DESCRIPTION
This adds a `disabled` property to `T1Link` which simply omits the link, only rendering children.