### PR TITLE
migrate showNotification to useNotification

### DIFF
--- a/src/components/ExecuteQuery.tsx
+++ b/src/components/ExecuteQuery.tsx
@@ -3,10 +3,7 @@ import { Config } from "../configs/config";
 import ExecuteQueryTab from "./ExecuteQueryTab";
 import { JsonCodeMirrorEditor } from "./JsonCodeMirrorEditor";
 import { useRecoilValue, useSetRecoilState } from "recoil";
-import {
-  showNotification,
-  snackbarNotificationState,
-} from "../atoms/snackbarNotificationState";
+import { useNotification } from "../atoms/snackbarNotificationState";
 import { executeQueryTabState } from "../atoms/executeQueryTabState";
 import { Button, Grid, Typography } from "@mui/material";
 
@@ -36,7 +33,6 @@ export const ExecuteQuery = ({
   currentState,
 }: IProps) => {
   const { MOCK_ENV, MOCK_INFO } = Config;
-  const setSnackbarNotification = useSetRecoilState(snackbarNotificationState);
   const [payload, setPayload] = useState("");
   const executeQueryTab = useRecoilValue(executeQueryTabState);
   const addState = (stateBefore: any, res: any) => {
@@ -50,6 +46,8 @@ export const ExecuteQuery = ({
     setAllStates([...allStates, stateObj]);
     setCurrentState(allStates.length);
   };
+  
+  const setNotification = useNotification();
 
   const execute = () => {
     try {
@@ -59,16 +57,12 @@ export const ExecuteQuery = ({
       setResponse(res.read_json());
       if (!(res.read_json().error && res.read_json().error.length > 0)) {
         addState(stateBefore, res);
-        showNotification(setSnackbarNotification, "Execution was successful!");
+        setNotification("Execution was successful!");
       } else {
         throw res.read_json().error;
       }
     } catch (err) {
-      showNotification(
-        setSnackbarNotification,
-        "Something went wrong while executing.",
-        "error"
-      );
+      setNotification("Something went wrong while executing.", { severity: "error" });
     }
   };
   const query = () => {
@@ -76,13 +70,9 @@ export const ExecuteQuery = ({
       const stateBefore = window.VM?.backend?.storage.dict["c3RhdGU="];
       const res = window.VM.query(MOCK_ENV, JSON.parse(payload));
       setResponse(JSON.parse(window.atob(res.read_json().ok)));
-      showNotification(setSnackbarNotification, "Query was successful!");
+      setNotification("Query was successful!");
     } catch (err) {
-      showNotification(
-        setSnackbarNotification,
-        "Something went wrong while querying.",
-        "error"
-      );
+      setNotification("Something went wrong while querying.", { severity: "error" });
     }
   };
   const onRunHandler = () => {

--- a/src/components/chains/Accounts.tsx
+++ b/src/components/chains/Accounts.tsx
@@ -20,7 +20,7 @@ import React, { useMemo, useState } from "react";
 import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import simulationState from "../../atoms/simulationState";
 import { validateAccountJSON } from "../../utils/fileUtils";
-import { showNotification, snackbarNotificationState } from "../../atoms/snackbarNotificationState";
+import { useNotification } from "../../atoms/snackbarNotificationState";
 
 const DEFAULT_VALUE = JSON.stringify({
   "address": "terra1f44ddca9awepv2rnudztguq5rmrran2m20zzd7",
@@ -33,7 +33,7 @@ const Accounts = () => {
   const [openDialog, setOpenDialog] = useState(false);
   const [simulation, setSimulation] = useRecoilState(simulationState);
   const [payload, setPayload] = useState(DEFAULT_VALUE);
-  const setSnackbarNotification = useSetRecoilState(snackbarNotificationState);
+  const setNotification = useNotification();
 
   const accounts = useRecoilValue(filteredAccountsByChainId(param.id as string)).accounts;
   const data = useMemo(() =>
@@ -54,17 +54,17 @@ const Accounts = () => {
     const json = JSON.parse(payload);
 
     if (payload.length === 0 || !validateAccountJSON(json)) {
-      showNotification(setSnackbarNotification, "Invalid Account JSON", "error");
+      setNotification("Invalid Account JSON", { severity: "error" });
       return;
     }
 
     if (accounts.find(acc => acc.id === json.id)) {
-      showNotification(setSnackbarNotification, "An account with this ID already exists", "error");
+      setNotification("An account with this ID already exists", { severity: "error" });
       return;
     }
 
     if (accounts.find(acc => acc.address === json.address)) {
-      showNotification(setSnackbarNotification, "An account with this address already exists", "error");
+      setNotification("An account with this address already exists", { severity: "error" });
       return;
     }
 
@@ -85,7 +85,7 @@ const Accounts = () => {
       },
     });
 
-    showNotification(setSnackbarNotification, "Account added successfully");
+    setNotification("Account added successfully");
     setOpenDialog(false);
   }
 
@@ -104,7 +104,7 @@ const Accounts = () => {
       },
     });
 
-    showNotification(setSnackbarNotification, "Account successfully removed");
+    setNotification("Account successfully removed");
   }
 
   const handleSetPayload = (payload: string) => {

--- a/src/components/chains/CodesAndInstances.tsx
+++ b/src/components/chains/CodesAndInstances.tsx
@@ -17,10 +17,7 @@ import simulationState from "../../atoms/simulationState";
 import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import { createContractInstance } from "../../utils/setupSimulation";
 import { base64ToArrayBuffer } from "../../utils/fileUtils";
-import {
-  showNotification,
-  snackbarNotificationState,
-} from "../../atoms/snackbarNotificationState";
+import { useNotification } from "../../atoms/snackbarNotificationState";
 import FileUpload from "../FileUpload";
 
 const CodesAndInstances = () => {
@@ -35,7 +32,7 @@ const CodesAndInstances = () => {
     .filter((instance) => !!instance);
   const [simulation, setSimulation] = useRecoilState(simulationState);
   const [payload, setPayload] = useState<string>("");
-  const setSnackbarNotification = useSetRecoilState(snackbarNotificationState);
+  const setNotification = useNotification();
   const [openDialog, setOpenDialog] = useState(false);
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
   const itemRef = useRef<any>();
@@ -60,11 +57,7 @@ const CodesAndInstances = () => {
 
   const handleInstantiate = () => {
     if (payload.length === 0) {
-      showNotification(
-        setSnackbarNotification,
-        "Payload cannot be empty",
-        "error"
-      );
+      setNotification("Payload cannot be empty", { severity: "error" });
       return;
     }
     const contractId = itemRef.current?.innerText;
@@ -72,11 +65,7 @@ const CodesAndInstances = () => {
       ?.find((code: any) => code.id === contractId)
       ?.wasmBinaryB64.split("data:application/wasm;base64,")[1];
     if (!binary) {
-      showNotification(
-        setSnackbarNotification,
-        "Failed to extract WASM bytecode",
-        "error"
-      );
+      setNotification("Failed to extract WASM bytecode", { severity: "error" });
       return;
     }
 
@@ -98,11 +87,7 @@ const CodesAndInstances = () => {
               newInstantiateMsg
             );
           } catch (e) {
-            showNotification(
-              setSnackbarNotification,
-              "Unable to instantiate with " + e,
-              "error"
-            );
+            setNotification("Unable to instantiate with " + e, { severity: "error" });
           }
         });
       }
@@ -141,7 +126,7 @@ const CodesAndInstances = () => {
         }),
       },
     });
-    showNotification(setSnackbarNotification, "Contract instance created");
+    setNotification("Contract instance created");
     setOpenDialog(false);
   };
 

--- a/src/components/chains/Config.tsx
+++ b/src/components/chains/Config.tsx
@@ -3,7 +3,7 @@ import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { useNavigate, useParams } from "react-router-dom";
 import filteredConfigsByChainId from "../../selectors/filteredConfigsByChainId";
-import { showNotification, snackbarNotificationState } from "../../atoms/snackbarNotificationState";
+import { useNotification } from "../../atoms/snackbarNotificationState";
 import { validateConfigJSON } from "../../utils/fileUtils";
 import simulationState from "../../atoms/simulationState";
 import { useState } from "react";
@@ -14,14 +14,14 @@ const Config = () => {
   const [simulation, setSimulation] = useRecoilState(simulationState);
   const jsonValue = JSON.stringify(configValue, null, 2);
   const [jsonPayload, setJsonPayload] = useState("");
-  const setSnackbarNotification = useSetRecoilState(snackbarNotificationState);
+  const setNotification = useNotification();
   const navigate = useNavigate();
 
   const handleOnClick = (e: any) => {
     e.preventDefault();
     const json = jsonPayload !== "" ? JSON.parse(jsonPayload) : JSON.parse(jsonValue);
     if (!validateConfigJSON(json)) {
-      showNotification(setSnackbarNotification, "Invalid Config JSON", "error");
+      setNotification("Invalid Config JSON", { severity: "error" });
       return;
     }
 
@@ -33,7 +33,7 @@ const Config = () => {
     const chainIds = newSimulation.simulation.chains.map((chain: any) => chain.chainId);
     // @ts-ignore
     if (json.chainId !== configValue.chainId && chainIds.includes(json.chainId)) {
-      showNotification(setSnackbarNotification, "Chain ID already exists", "error");
+      setNotification("Chain ID already exists", { severity: "error" });
       return;
     }
     newSimulation = {
@@ -51,7 +51,7 @@ const Config = () => {
     if (json.chainId !== param.id) {
       navigate(`/chains/${json.chainId}`);
     }
-    showNotification(setSnackbarNotification, "Config updated successfully");
+    setNotification("Config updated successfully");
   };
 
   const handleSetPayload = (payload: string) => {


### PR DESCRIPTION
## Description
Migrate all occurrences of `showNotification` to `useNotification`

## Test steps

1. with an active simulation, navigate to an accounts page.
2. add a new account with invalid JSON & verify error snackbar notification.
3. add account with existing ID and/or address & verify error snackbar notification.
4. add valid account & verify success snackbar notification.
5. remove an account & verify success snackbar notification.

similar changes were applied to CodesAndInstances, Config & ExecuteQuery components