### PR TITLE
Remove recoil persist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "react-object-table-viewer": "^1.0.7",
         "react-router-dom": "^6.3.0",
         "recoil": "^0.7.5",
-        "recoil-persist": "^4.2.0",
         "sass": "^1.54.8",
         "save": "^2.5.0",
         "typescript": "^4.7.4",
@@ -32920,14 +32919,6 @@
         }
       }
     },
-    "node_modules/recoil-persist": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
-      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
-      "peerDependencies": {
-        "recoil": "^0.7.2"
-      }
-    },
     "node_modules/recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -63419,11 +63410,6 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
-    },
-    "recoil-persist": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
-      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA=="
     },
     "recursive-readdir": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-object-table-viewer": "^1.0.7",
     "react-router-dom": "^6.3.0",
     "recoil": "^0.7.5",
-    "recoil-persist": "^4.2.0",
     "sass": "^1.54.8",
     "save": "^2.5.0",
     "typescript": "^4.7.4",

--- a/src/atoms/simulationState.ts
+++ b/src/atoms/simulationState.ts
@@ -1,5 +1,4 @@
 import { atom } from "recoil";
-import { recoilPersist } from "recoil-persist";
 
 export type Simulation = {
   simulation: {
@@ -35,11 +34,9 @@ export type Instance = {
   message: unknown;
 }
 
-const {persistAtom} = recoilPersist({key: "simulationState"});
 const simulationState = atom<Simulation>({
   key: 'simulationState',
   default: {simulation: {chains: []}},
-  effects_UNSTABLE: [persistAtom]
 });
 
 export default simulationState;

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -4,6 +4,13 @@ import "../../index.css";
 
 const Home = () => {
   const [wasmBuffers, setWasmBuffers] = React.useState<ArrayBuffer[]>([]);
+
+  window.onbeforeunload = function(evt) {
+    evt.preventDefault();
+    evt.returnValue = '';
+    return null;
+  };
+
   return (
     <WelcomeScreen
       wasmBuffers={wasmBuffers}


### PR DESCRIPTION
## Issue link

[WL-443](https://terran-one.atlassian.net/browse/WL-XXX)

## Description

Remove `recoil-persist`, as we're not supporting serialisation at this point. This is a prerequisite for moving `CWSimulateEnv` to recoil.

## Test steps

1. Test contract instantiation (off-by-one error is known)
2. Try refreshing the page or navigating to home
