### PR TITLE
Restore previous version of location-based menu select

### DIFF
--- a/src/atoms/selectedMenuItemState.ts
+++ b/src/atoms/selectedMenuItemState.ts
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const selectedMenuItemState = atom({
-  key: 'selectedMenuItemState',
-  default: '',
-});

--- a/src/components/home/WelcomeScreen.tsx
+++ b/src/components/home/WelcomeScreen.tsx
@@ -6,7 +6,6 @@ import { Button, Grid, Paper, styled, Typography } from "@mui/material";
 import React, { HTMLAttributeAnchorTarget, PropsWithChildren, useCallback, useState } from "react";
 import { To } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
-import { selectedMenuItemState } from "../../atoms/selectedMenuItemState";
 import { useNotification } from "../../atoms/snackbarNotificationState";
 import { DEFAULT_CHAIN } from "../../configs/variables";
 import { useCreateChainForSimulation, useStoreCode } from "../../utils/setupSimulation";
@@ -32,7 +31,6 @@ export const WelcomeScreen = ({setWasmBuffers, wasmBuffers}: IProps) => {
   const setNotification = useNotification();
   const createChainForSimulation = useCreateChainForSimulation();
   const storeCode = useStoreCode();
-  const setSelectedMenuItem = useSetRecoilState(selectedMenuItemState)
 
   const onCreateNewEnvironment = useCallback(() => {
     if (!file) {
@@ -45,7 +43,6 @@ export const WelcomeScreen = ({setWasmBuffers, wasmBuffers}: IProps) => {
       bech32Prefix: 'terra',
     });
     storeCode(DEFAULT_CHAIN, file.filename, file.buffer);
-    setSelectedMenuItem(`chains/${DEFAULT_CHAIN}/config`);
   }, [file]);
 
   const onAcceptFile = useCallback((filename: string, buffer: Buffer) => {


### PR DESCRIPTION
## Description
Removes recoil `selectedMenuState` in favor of `location`-based selection of active sidebar/drawer menu item

## Test steps
1. Create new simulation
2. Verify selected item in sidebar is terratest-1/config
3. Collapse terratest-1, expand, verify it's still selected
4. Navigate to State
5. Reload page, re-add terratest-1, verify State is still selected
