### PR TITLE
Feat/close kv iter storage

### DIFF
--- a/src/utils/setupSimulation.ts
+++ b/src/utils/setupSimulation.ts
@@ -139,14 +139,10 @@ export function useCreateContractInstance() {
   const [simulateEnv, setSimulateEnv] = useRecoilState(cwSimulateEnvState);
 
   return useCallback(async (chainId: string, code: Code, info: MsgInfo, instantiateMsg: any): Promise<CWContractInstance> => {
-    console.log('0.', simulateEnv.chains[chainId]);
     const _simulateEnv_ = cloneSimulateEnv(simulateEnv);
     const _chain_ = cloneChain(_simulateEnv_.chains[chainId]);
-    console.log('1.', _chain_);
     const contract = await _chain_.instantiateContract(code.codeId);
-    console.log('2.', _chain_);
     contract.instantiate(info, instantiateMsg);
-    console.log('3.', _chain_);
 
     _simulateEnv_.chains[_chain_.chainId] = _chain_;
     setSimulateEnv(_simulateEnv_);


### PR DESCRIPTION
## Issue link

[WL-461](https://terran-one.atlassian.net/browse/WL-461)

## Description

Fix cloning BasicKVIterStorage, which fixes the problem of adding a second instance wiping the state of the first instance.

## Test steps

1. Instantiate a code twice
2. Navigate to _State_
3. Observe both states are there
