### PR TITLE
Show state on clicking of stepper.

### DIFF
--- a/src/components/simulation/StateStepper.tsx
+++ b/src/components/simulation/StateStepper.tsx
@@ -68,8 +68,8 @@ export default function StateStepper({ chainId, contractAddress }: IProps) {
   const executionHistory = executeHistory(chainId, contractAddress);
   const [stepState, setStepState] = useRecoilState(blockState);
   const handleStateView = (state: { dict: { [x: string]: string } }) => {
-    // TODO: Rewrite
-    // setStepState(JSON.parse(window.atob(state.dict["c3RhdGU="])));
+    // @ts-ignore
+    setStepState(JSON.parse(window.atob(state.dict._root.entries[0][1])));
   };
 
   const handleStep =


### PR DESCRIPTION
## Issue link

[WL-417](https://terran-one.atlassian.net/browse/WL-417)

## Description
Added state view on click of stepper icon

## Test steps

1. Go to simulate page.
2. On State stepper, click on step icon and now you can see state on right hand side.
