### PR TITLE
Added color coding to error state. Also no state will be shown on error.

### DIFF
--- a/src/components/simulation/StateStepper.tsx
+++ b/src/components/simulation/StateStepper.tsx
@@ -91,6 +91,9 @@ export default function StateStepper({ chainId, contractAddress }: IProps) {
                 "& .MuiStepIcon-root": {
                   color: response.error ? "red" : "",
                 },
+                "& .MuiStepLabel-root .Mui-active": {
+                  color: "#1976d2",
+                },
               }}
             >
               <StepLabel ref={containerRef}>


### PR DESCRIPTION
## Issue link

[WL-477](https://terran-one.atlassian.net/browse/WL-477)

## Description
1) The error states will now be highlighted with red color.

## Test steps

1. Instantiate a contract.
2. Go to simulation page.
3. Perform some execute operations with right message and then perform some other with incorrect message. Now you can see some red colored states appearing on State stepper.
