### PR TITLE
Make error highlight colour more clear

### DIFF
--- a/src/components/simulation/StateStepper.tsx
+++ b/src/components/simulation/StateStepper.tsx
@@ -89,10 +89,10 @@ export default function StateStepper({ chainId, contractAddress }: IProps) {
               onClick={handleStep(index, state)}
               sx={{
                 "& .MuiStepIcon-root": {
-                  color: response.error ? "red" : "",
+                  color: response.error ? "red" : "#00C921",
                 },
                 "& .MuiStepLabel-root .Mui-active": {
-                  color: response.error ? "maroon" : "#1976d2",
+                  color: response.error ? "#690000" : "#006110",
                 },
               }}
             >


### PR DESCRIPTION
## Issue link

[WL-477](https://terran-one.atlassian.net/browse/WL-477)

## Description

Make state stepper error highlight colour different from valid highlight colour. Also make valid states green.

## Test steps

1. Instantiate a contract
2. Perform some valid executions
3. Perform some invalid ones
4. Click through the states
5. Verify it's obvious which are valid/invalid states when highlighted
