### PR TITLE
Restructure overall layout, especially Drawer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,48 +1,33 @@
-import { Box, Grid, SxProps, Theme } from "@mui/material";
+import { Grid, SxProps, Theme } from "@mui/material";
 import { Route, Routes } from "react-router-dom";
 import State from "./components/chains/State";
 import Config from "./components/chains/Config";
 import Accounts from "./components/chains/Accounts";
-import MenuDrawer from "./components/drawer";
+import T1AppBar from "./components/drawer/T1AppBar";
 import Home from "./components/home/Home";
 import VoidScreen from "./components/home/VoidScreen";
+import MainScreen from "./components/simulation/MainScreen";
 import Simulation from "./components/simulation/Simulation";
 
 function App() {
-  const rootSx: SxProps<Theme> = {
-    display: 'flex',
-    width: '100vw',
-    height: '100vh',
-    pt: '70px',
-  };
-
   return (
-    <Box sx={rootSx} className="T1App-root">
-      <MenuDrawer/>
-      <Grid
-        container
-        component="main"
-        direction="column"
-        flex={1}
-        sx={{
-          p: 3,
-          overflow: "hidden",
-        }}
-      >
-        <Routes>
-          <Route index element={<Home/>}/>
+    <Grid container direction="column" width="100vw" height="100vh" className="T1App-root">
+      <T1AppBar />
+      <Routes>
+        <Route index element={<Home/>}/>
 
+        <Route element={<MainScreen/>}>
           {/*TODO: A CWSimulateApp only contain a single chain. Wrap everything under /simulation instead*/}
           {/* <Chains /> ensures the :chainId exists. Do not remove. */}
           <Route path="config" element={<Config/>}/>
           <Route path="state" element={<State/>}/>
           <Route path="accounts" element={<Accounts/>}/>
           <Route path="instances/:instanceAddress" element={<Simulation/>}/>
+        </Route>
 
-          <Route path="*" element={<VoidScreen/>}/>
-        </Routes>
-      </Grid>
-    </Box>
+        <Route path="*" element={<VoidScreen/>}/>
+      </Routes>
+    </Grid>
   );
 }
 

--- a/src/components/drawer/T1AppBar.tsx
+++ b/src/components/drawer/T1AppBar.tsx
@@ -30,7 +30,7 @@ const T1AppBar = React.memo((props: IT1AppBarProps) => {
   const location = useLocation();
 
   return (
-    <AppBar position="fixed" sx={{backgroundColor: ORANGE_3}}>
+    <AppBar position="static" sx={{backgroundColor: ORANGE_3}}>
       <Toolbar sx={{justifyContent: "space-between"}}>
         <div>
           {location.pathname === "/" && (

--- a/src/components/drawer/T1Drawer.tsx
+++ b/src/components/drawer/T1Drawer.tsx
@@ -1,12 +1,14 @@
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import { Box, Divider, Drawer, ListItemButton, styled, SxProps, Theme } from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { Box, ClickAwayListener, Divider, Grid, IconButton, ListItemButton, Paper, styled, SxProps, Theme } from "@mui/material";
+import Slide from "@mui/material/Slide";
 import TreeView from "@mui/lab/TreeView";
 import React, { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import Logo from "./Logo";
 import ChainsMenuItem from "./ChainsMenuItem";
 import SimulationMenuItem from "./SimulationMenuItem";
-import { DEFAULT_CHAIN } from "../../configs/variables";
+import { DEFAULT_CHAIN, GREY_4 } from "../../configs/variables";
 
 type MenuDrawerAPI = {
   register(data: MenuDrawerRegisterOptions): void;
@@ -36,49 +38,124 @@ const DrawerHeader = styled("div")(({theme}) => ({
 }));
 
 export interface IT1Drawer {
-  width: number;
+  barWidth?: number;
+  drawerWidth?: number;
 }
 
 const T1Drawer = React.memo((props: IT1Drawer) => {
   const {
-    width: drawerWidth,
+    barWidth = 50,
+    drawerWidth = 250,
   } = props;
+  
+  const [open, setOpen] = useState(true);
 
   return (
-    <Box component="nav">
-      <Drawer
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Box
         sx={{
-          width: drawerWidth,
-          flexShrink: 0,
-          "& .MuiDrawer-paper": {
-            boxSizing: "border-box",
-            width: drawerWidth,
-          },
+          position: 'relative',
         }}
-        variant="permanent"
-        open
+      >
+        <DrawerBar width={barWidth}>
+          <IconButton onClick={() => setOpen(true)}>
+            <MenuIcon />
+          </IconButton>
+        </DrawerBar>
+        <Drawer
+          width={drawerWidth}
+          open={open}
+        >
+          <HierarchyMenu
+            sx={{
+              marginTop: 2,
+              '& .MuiTreeItem-content': {
+                py: 1,
+              },
+            }}
+          >
+            <SimulationMenuItem/>
+            <ChainsMenuItem/>
+          </HierarchyMenu>
+        </Drawer>
+      </Box>
+    </ClickAwayListener>
+  );
+});
+
+export default T1Drawer;
+
+interface IDrawerBar {
+  children?: ReactNode;
+  width: number;
+}
+
+const DrawerBar = React.forwardRef<HTMLDivElement | null, IDrawerBar>(({ children, width }, ref) => {
+  return (
+    <Paper
+      ref={ref}
+      sx={{
+        position: 'relative',
+        width,
+        height: '100%',
+        border: 0,
+        borderRadius: 0,
+        borderRight: `1px solid ${GREY_4}`,
+        zIndex: 100,
+      }}
+    >
+      <Grid
+        container
+        direction="column"
+        alignItems="center"
+        height="100%"
+        sx={{
+          pt: 1,
+          pb: 1,
+        }}
+      >
+        {children}
+      </Grid>
+    </Paper>
+  );
+});
+
+interface ICustomDrawer {
+  children?: ReactNode;
+  width: number;
+  open: boolean;
+}
+
+function Drawer({ children, width, open }: ICustomDrawer) {
+  return (
+    <Slide
+      direction="right"
+      in={open}
+    >
+      <Paper
+        component="nav"
+        sx={{
+          position: 'absolute',
+          height: '100%',
+          top: 0,
+          left: '100%',
+          width,
+          boxSizing: 'border-box',
+          border: 0,
+          borderRadius: 0,
+          borderRight: `1px solid ${GREY_4}`,
+          zIndex: 99,
+        }}
       >
         <DrawerHeader>
           <Logo LinkComponent={ListItemButton}/>
         </DrawerHeader>
         <Divider/>
-        <HierarchyMenu
-          sx={{
-            marginTop: 2,
-            '& .MuiTreeItem-content': {
-              py: 1,
-            },
-          }}
-        >
-          <SimulationMenuItem/>
-          <ChainsMenuItem/>
-        </HierarchyMenu>
-      </Drawer>
-    </Box>
-  );
-});
-
-export default T1Drawer;
+        {children}
+      </Paper>
+    </Slide>
+  )
+}
 
 interface IHierarchyMenuProps {
   children?: ReactNode;

--- a/src/components/drawer/T1Drawer.tsx
+++ b/src/components/drawer/T1Drawer.tsx
@@ -58,7 +58,7 @@ const T1Drawer = React.memo((props: IT1Drawer) => {
         }}
       >
         <DrawerBar width={barWidth}>
-          <IconButton onClick={() => setOpen(true)}>
+          <IconButton onClick={() => setOpen(curr => !curr)}>
             <MenuIcon />
           </IconButton>
         </DrawerBar>

--- a/src/components/drawer/T1Drawer.tsx
+++ b/src/components/drawer/T1Drawer.tsx
@@ -48,7 +48,7 @@ const T1Drawer = React.memo((props: IT1Drawer) => {
     drawerWidth = 250,
   } = props;
   
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
 
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>

--- a/src/components/drawer/index.tsx
+++ b/src/components/drawer/index.tsx
@@ -13,7 +13,7 @@ export default function MenuDrawer() {
     <>
       <CssBaseline/>
       <T1AppBar/>
-      {location.pathname !== "/" && <T1Drawer width={DRAWER_WIDTH}/>}
+      {location.pathname !== "/" && <T1Drawer barWidth={40} drawerWidth={DRAWER_WIDTH}/>}
     </>
   );
 }

--- a/src/components/home/WelcomeScreen.tsx
+++ b/src/components/home/WelcomeScreen.tsx
@@ -64,17 +64,11 @@ export const WelcomeScreen = () => {
 
   return (
     <Grid
-      xs={12}
-      md={12}
-      lg={12}
-      xl={12}
       container
       item
-      sx={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
     >
       <Grid
         xs={12}

--- a/src/components/simulation/MainScreen.tsx
+++ b/src/components/simulation/MainScreen.tsx
@@ -1,0 +1,33 @@
+import { Grid } from "@mui/material";
+import { Outlet } from "react-router-dom";
+import T1Drawer from "../drawer/T1Drawer";
+
+export interface IMainScreen {}
+
+export default function MainScreen(props: IMainScreen) {
+  return (
+    <Grid
+      item
+      container
+      direction="row"
+      flex={1}
+    >
+      <T1Drawer
+        barWidth={50}
+        drawerWidth={250}
+      />
+      <Grid
+        container
+        component="main"
+        direction="column"
+        flex={1}
+        sx={{
+          p: 3,
+          overflow: "hidden",
+        }}
+      >
+        {<Outlet/>}
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { CssBaseline } from "@mui/material";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import React from "react";
@@ -13,6 +14,7 @@ const root = ReactDOM.createRoot(document.getElementById("root")!);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
+      <CssBaseline />
       <PageRefreshConfirmation/>
       <SnackbarNotification/>
       <App/>


### PR DESCRIPTION
## Description
Restructure overall layout:
- Separate `WelcomeScreen` from new `MainScreen`
- Replace `position: fixed` components with static for easier layout styling
- Replace MUI drawer with near-identical custom implementation

## Test steps
1. Verify WelcomeScreen looks the same.
2. Create new simulation.
3. SimulationScreen should now have a slim sidebar w/ Burger Menu IconButton.
4. Click BurgerMenu. Layout-adjusted drawer should slide in from the left above main content.
5. Click away (!= drawer bar, drawer content). Drawer should close.
