### PR TITLE
Add a copy address action to the contract instances

### DIFF
--- a/src/components/drawer/InstanceMenuItem.tsx
+++ b/src/components/drawer/InstanceMenuItem.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Dialog, DialogActions, DialogContent, DialogTitle, MenuItem } from "@mui/material";
 import { useDeleteInstance, } from "../../utils/simulationUtils";
+import { useClipboard } from '../../utils/hookUtils'
 
 export interface IInstanceMenuItemProps {
   chainId: string;
@@ -16,19 +17,27 @@ export default function InstanceMenuItem(props: IInstanceMenuItemProps) {
   } = props;
   const [showDeleteInstance, setShowDeleteInstance] = useState(false);
   const navigate = useNavigate();
+  const { copyToClipboard } = useClipboard()
+
   return (
     <T1MenuItem
       label={instance}
       nodeId={`instances/${instance}`}
       link={`/instances/${instance}`}
       textEllipsis
-      tooltip={`${instance}`}
-      options={[
+      tooltip={instance}
+      options={({close}) => [
         <MenuItem
           key="delete-instance"
           onClick={() => {
             setShowDeleteInstance(true);
           }}>Delete</MenuItem>,
+        <MenuItem
+          key="copy-instance-address"
+          onClick={() => {
+            copyToClipboard(instance);
+            close();
+          }}>Copy Address</MenuItem>
       ]}
       optionsExtras={({close}) => [
         <DeleteInstanceDialog

--- a/src/utils/hookUtils.ts
+++ b/src/utils/hookUtils.ts
@@ -1,0 +1,5 @@
+export const useClipboard = () => {
+  const copyToClipboard = (data: string) => navigator.clipboard.writeText(data);
+
+  return { copyToClipboard }
+}


### PR DESCRIPTION
## Issue link

N/A

## Description
Add a copy address action to each of the instances on the sidebar.


## Test steps

1. Instantiate an instance of a binary
2. Click the kebab menu
4. Click "Copy Address"
