### PR TITLE
Fix undefined error in ContractsSubMenu

### DIFF
--- a/src/components/drawer/ContractsSubMenu.tsx
+++ b/src/components/drawer/ContractsSubMenu.tsx
@@ -38,7 +38,7 @@ export default function ContractsSubMenu(props: IContractsSubMenuProps) {
   const {metadata} = useAtomValue(simulationMetadataState);
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
   //@ts-ignore
-  const codesFromStore = app.store.getIn(["wasm", "codes"]).toObject();
+  const codesFromStore = app.store.getIn(["wasm", "codes"])?.toObject() ?? {};
   const codes = {} as Codes;
   for (const key of Object.keys(codesFromStore)) {
     const fileName = metadata.codes[parseInt(key)]?.name;


### PR DESCRIPTION
## Description
When reloading page (and thus clearing simulation) page would crash upon opening Contracts/Codes drawer menu. Fixed.

## Test steps
1. Create a new simulation
2. Reload page
3. Open Contracts submenu. It shouldn't crash but simply show an empty drawer (except for header)
