### PR TITLE
Fix stepper alignment and hide state from drawer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Grid } from "@mui/material";
 import { Route, Routes } from "react-router-dom";
-import State from "./components/chains/State";
 import Accounts from "./components/chains/Accounts";
 import T1AppBar from "./components/drawer/T1AppBar";
 import VoidScreen from "./components/screens/VoidScreen";
@@ -20,7 +19,6 @@ function App() {
             <Routes>
               <Route index element={<WelcomeScreen/>}/>
               <Route element={<SimulationScreen/>}>
-                <Route path="state" element={<State/>}/>
                 <Route path="accounts" element={<Accounts/>}/>
                 <Route path="instances/:instanceAddress" element={<Simulation/>}/>
               </Route>

--- a/src/components/drawer/SettingsSubMenu.tsx
+++ b/src/components/drawer/SettingsSubMenu.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import cwSimulateAppState from "../../atoms/cwSimulateAppState";
 import SubMenuHeader from "./SubMenuHeader";
 import {
@@ -16,6 +16,8 @@ import React, { ChangeEvent, ReactNode, useState } from "react";
 import { useNotification } from "../../atoms/snackbarNotificationState";
 import { CWSimulateApp } from "@terran-one/cw-simulate";
 import { TerraConfig } from "../../configs/constants";
+import { useNavigate } from "react-router-dom";
+import { stepTraceState, traceState } from "../../atoms/simulationPageAtoms";
 
 export interface ISettingsSubMenuProps {
 }
@@ -30,12 +32,18 @@ export default function SettingsSubMenu(props: ISettingsSubMenuProps) {
   const [chainConfigFormValues, setChainConfigFormValues] = useState<IChainConfigFormValues>({} as IChainConfigFormValues);
   const setNotification = useNotification();
   const [openResetSimulationDialog, setOpenResetSimulationDialog] = useState(false);
+  const navigate = useNavigate();
+  const setStepTrace = useSetAtom(stepTraceState);
+  const setTraces = useSetAtom(traceState);
   const handleResetSimulation = (e: any) => {
     setSimulateApp({
       app: new CWSimulateApp(TerraConfig)
     });
     setOpenResetSimulationDialog(false);
+    navigate('/accounts');
   };
+  setStepTrace([]);
+  setTraces([]);
 
   const handleSaveConfig = () => {
     app.chainId = chainConfigFormValues.chainId;

--- a/src/components/drawer/T1Drawer.tsx
+++ b/src/components/drawer/T1Drawer.tsx
@@ -54,13 +54,6 @@ const T1Drawer = (props: IT1Drawer) => {
             tooltip="Contract Instances"
           />
           <MenuIconButton
-            menu="states"
-            Icon={StorageIcon}
-            setMenu={setMenu}
-            tooltip="All States"
-            onClick={() => {navigate('/state')}}
-          />
-          <MenuIconButton
             menu="accounts"
             Icon={RecentActorsIcon}
             setMenu={setMenu}
@@ -111,7 +104,7 @@ interface IDrawerBar {
 
 const DrawerBar = React.forwardRef<HTMLDivElement | null, IDrawerBar>(({ children, width }, ref) => {
   const theme = useTheme();
-  
+
   return (
     <Paper
       ref={ref}
@@ -149,7 +142,7 @@ interface ICustomDrawer {
 
 function Drawer({ children, width, open }: ICustomDrawer) {
   const theme = useTheme();
-  
+
   return (
     <Slide
       direction="right"

--- a/src/components/simulation/StateStepper.tsx
+++ b/src/components/simulation/StateStepper.tsx
@@ -143,7 +143,7 @@ function renderTreeItems(
     if (trace.trace?.length === 0) {
       return (
         <StyledTreeItem
-          sx={{ ml: depth * 2 }}
+          sx={{ml: depth >= 1 ? depth * 2 : 0}}
           nodeId={
             prefix !== "" ? `${prefix}-${index}-${depth}` : `${index}-${depth}`
           }
@@ -154,6 +154,7 @@ function renderTreeItems(
     } else {
       return (
         <StyledTreeItem
+          sx={{ml: depth >= 1 ? depth * 2 : 0}}
           nodeId={
             prefix !== "" ? `${prefix}-${index}-${depth}` : `${index}-${depth}`
           }


### PR DESCRIPTION
## Issue link

[WL-XXX](https://terran-one.atlassian.net/browse/WL-XXX)

## Description

Before

<img width="416" alt="Screen Shot 2022-11-14 at 3 36 56 PM" src="https://user-images.githubusercontent.com/4691966/201760781-c1e2b8e2-2be7-49a8-86b3-4d383e0f22d0.png">
After
<img width="343" alt="Screen Shot 2022-11-14 at 3 36 53 PM" src="https://user-images.githubusercontent.com/4691966/201760802-06a6de49-94b4-406c-9251-867a84cc6404.png">

## Test steps

1. Upload WASM contract
2. Execute message
3. Verify stepper icons are properly aligned
