### PR TITLE
Improve Codes & Instances tooltips

### DIFF
--- a/src/components/drawer/ContractsSubMenu.tsx
+++ b/src/components/drawer/ContractsSubMenu.tsx
@@ -13,7 +13,8 @@ import {
   ListItemIcon,
   ListItemText,
   MenuItem,
-  TextField
+  TextField,
+  Typography
 } from "@mui/material";
 import type { CodeInfo } from "@terran-one/cw-simulate";
 import { useCallback, useState } from "react";
@@ -84,6 +85,9 @@ function CodeMenuItem({code}: ICodeMenuItemProps) {
     <T1MenuItem
       label={code.name}
       textEllipsis
+      tooltip={
+        <Typography variant="body2">{code.name} ({code.codeId})</Typography>
+      }
       options={({close}) => [
         <MenuItem
           key="instantiate"

--- a/src/components/drawer/T1MenuItem.tsx
+++ b/src/components/drawer/T1MenuItem.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
-import Tooltip from "@mui/material/Tooltip";
+import Tooltip, { TooltipProps } from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import type { SxProps, Theme } from "@mui/material";
 import { MouseEvent, ReactNode, useCallback, useMemo, useState } from "react";
@@ -20,7 +20,8 @@ export interface IT1MenuItemProps {
   icon?: ReactNode;
   sx?: SxProps<Theme>;
   menuRef?: React.Ref<HTMLUListElement>;
-  tooltip?: string;
+  tooltip?: ILabelProps['tooltip'];
+  tooltipProps?: ILabelProps['tooltipProps'];
   onClick?(e: MouseEvent): void;
 }
 
@@ -40,6 +41,7 @@ export default function T1MenuItem(props: IT1MenuItemProps) {
     sx,
     menuRef,
     tooltip,
+    tooltipProps,
     onClick: _onClick,
     ...rest
   } = props;
@@ -103,7 +105,7 @@ export default function T1MenuItem(props: IT1MenuItemProps) {
         onClick={onClick}
         {...rest}
       >
-        <Label ellipsis={textEllipsis} tooltip={tooltip}>{label}</Label>
+        <Label ellipsis={textEllipsis} tooltip={tooltip} tooltipProps={tooltipProps}>{label}</Label>
       </ListItemButton>
     </ListItem>
   )
@@ -112,7 +114,8 @@ export default function T1MenuItem(props: IT1MenuItemProps) {
 interface ILabelProps {
   children: NonNullable<ReactNode>;
   ellipsis: boolean;
-  tooltip?: string | undefined;
+  tooltip?: ReactNode;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
 }
 
 function Label(props: ILabelProps) {
@@ -120,15 +123,16 @@ function Label(props: ILabelProps) {
     children,
     ellipsis,
     tooltip,
+    tooltipProps,
   } = props;
 
   if (!ellipsis) {
     return (
-      <Typography variant="body1">{children}</Typography>
+      <Typography variant="body1" className="T1MenuItem-label">{children}</Typography>
     )
   }
   return (
-    <Tooltip title={tooltip === undefined ? children : tooltip} placement="right">
+    <Tooltip title={tooltip === undefined ? children : tooltip} placement="right" arrow {...tooltipProps}>
       <Typography
         variant="body1"
         sx={{


### PR DESCRIPTION
## Description
Improve tooltips for codes & instances.

`T1MenuItem` now takes any `ReactNode` for its tooltips, not just strings, which allows for richer content.

## Test steps
1. Create new simulation
2. Instantiate contract. Notice code ID is now part of tooltip.
3. Open instances drawer. Notice code name + code ID are now part of tooltip.
