### PR TITLE
Fix codes desync

### DIFF
--- a/src/CWSimulationBridge.ts
+++ b/src/CWSimulationBridge.ts
@@ -231,9 +231,9 @@ export function useAccounts(bridge: CWSimulationBridge) {
 
 export function useCodes(bridge: CWSimulationBridge) {
   return bridge.useWatcher(
-    app => (app.store.getIn(['wasm', 'codes']) as Map<number, CodeInfo>)?.toObject(),
-    // TODO: we need cleaner storage. CodeInfo is NOT persistent
-    () => false,
+    app => (app.store.getIn(['wasm', 'codes']) as Map<number, CodeInfo>)?.toObject() ?? {},
+    compareDeep,
+    cloneCodes,
   )
 }
 
@@ -283,7 +283,7 @@ export function compareDeep(lhs: any, rhs: any): boolean {
   // easy cases
   if (lhs === rhs)
     return true;
-  if (typeof lhs !== 'object' || typeof rhs !== 'object')
+  if ([rhs, lhs].find(v => !v || typeof v !== 'object'))
     return lhs === rhs;
 
   // assert both objects have same keys
@@ -300,4 +300,12 @@ export function compareDeep(lhs: any, rhs: any): boolean {
       return false;
   }
   return true;
+}
+
+function cloneCodes(codes: Record<number, CodeInfo>): Record<number, CodeInfo> {
+  return Object.fromEntries(
+    Object.entries(codes).map(
+      ([codeId, info]) => [codeId, {...info}]
+    )
+  )
 }

--- a/src/components/drawer/ContractsSubMenu.tsx
+++ b/src/components/drawer/ContractsSubMenu.tsx
@@ -34,7 +34,7 @@ export default function ContractsSubMenu(props: IContractsSubMenuProps) {
   const sim = useSimulation();
 
   const [openUploadDialog, setOpenUploadDialog] = useState(false);
-  const codes = Object.values(useCodes(sim) || {}).filter(c => !c.hidden);
+  const codes = Object.values(useCodes(sim)).filter(c => !c.hidden);
 
   return (
     <>

--- a/src/components/drawer/SettingsSubMenu.tsx
+++ b/src/components/drawer/SettingsSubMenu.tsx
@@ -49,7 +49,7 @@ export default function SettingsSubMenu(props: ISettingsSubMenuProps) {
       setNotification("Chain config saved successfully");
     }
     catch (err: any) {
-      console.log(err);
+      console.error(err);
       setNotification("Something went wrong while reconfiguring chain.", {severity: 'error'});
     }
   };

--- a/src/components/simulation/StateTab.tsx
+++ b/src/components/simulation/StateTab.tsx
@@ -12,7 +12,6 @@ export const StateTab = ({}: IStateTabProps) => {
   const compareStateObj = useAtomValue(compareStates);
   const currentJSON = useAtomValue(blockState);
   const [isDiff, setIsDiff] = useState(false);
-  console.log(compareStateObj);
   useEffect(() => {
     setIsDiff(
       Object.keys(compareStateObj.state1).length !== 0 &&


### PR DESCRIPTION
## Description
Changes to codes through `CWSimulationBridge` now properly reflect in UI

Previously, deleting a code could cause the entire UI to desync and changes would only reflect upon reopening the drawer. This is now fixed.

## Test steps
1. Create a new simulation
2. Upload another contract. Verify the drawer UI updates.
3. Delete a contract. Verify the drawer UI updates.
