### PR TITLE
Placed close diff button in tabs row.

### DIFF
--- a/src/atoms/simulationPageAtoms.ts
+++ b/src/atoms/simulationPageAtoms.ts
@@ -23,3 +23,4 @@ export const compareStates = atom<{ state1: { [k: string]: string; }; state2: { 
 });
 export const stepTraceState = atom<TraceLog | undefined>(undefined);
 export const activeStepState = atom<string>('');
+export const stateDiffOpen = atom<boolean>(false);

--- a/src/components/simulation/StateTab.tsx
+++ b/src/components/simulation/StateTab.tsx
@@ -1,8 +1,12 @@
 import Box from "@mui/material/Box";
 import ReactDiffViewer from "@terran-one/react-diff-viewer";
-import { useAtomValue } from "jotai";
-import React, { useEffect, useState } from "react";
-import { blockState, compareStates } from "../../atoms/simulationPageAtoms";
+import { useAtomValue, useAtom } from "jotai";
+import React, { useEffect } from "react";
+import {
+  blockState,
+  compareStates,
+  stateDiffOpen,
+} from "../../atoms/simulationPageAtoms";
 import T1JsonTree from "../T1JsonTree";
 import CloseDiff from "./CloseDiff";
 
@@ -11,7 +15,7 @@ export interface IStateTabProps {}
 export const StateTab = ({}: IStateTabProps) => {
   const compareStateObj = useAtomValue(compareStates);
   const currentJSON = useAtomValue(blockState);
-  const [isDiff, setIsDiff] = useState(false);
+  const [isDiff, setIsDiff] = useAtom(stateDiffOpen);
   useEffect(() => {
     setIsDiff(
       Object.keys(compareStateObj.state1).length !== 0 &&
@@ -22,11 +26,6 @@ export const StateTab = ({}: IStateTabProps) => {
   if (isDiff) {
     return (
       <Box>
-        <CloseDiff
-          onClick={() => {
-            setIsDiff(false);
-          }}
-        />
         <ReactDiffViewer
           oldValue={JSON.stringify(compareStateObj.state1)}
           newValue={JSON.stringify(compareStateObj.state2)}


### PR DESCRIPTION
## Issue link

[WL-XXX](https://trello.com/c/wr05LBOU/54-move-closing-button-for-state-diff-from-inside-the-output-render-to-tabs-row)

## Description
The close diff button earlier was inside the box where json appears. It's now placed in tabs row as it makes more sense to be placed there.

## Test steps

1. Go to simulation page.
2. Perform some executions and activate state diff. Now you can see the close diff button in State tab row.
