### PR TITLE
Remove highly specific code from generic component

### DIFF
--- a/src/atoms/simulationPageAtoms.ts
+++ b/src/atoms/simulationPageAtoms.ts
@@ -17,10 +17,19 @@ export interface IRequest {
 }
 
 export const blockState = atom<JSON | undefined>(undefined);
-export const compareStates = atom<{ state1: { [k: string]: string; }; state2: { [k: string]: string; } }>({
-  state1: {},
-  state2: {},
+export const compareStates = atom<{ state1: object | undefined; state2: object | undefined }>({
+  state1: undefined,
+  state2: undefined,
 });
 export const stepTraceState = atom<TraceLog | undefined>(undefined);
 export const activeStepState = atom<string>('');
-export const stateDiffOpen = atom<boolean>(false);
+
+// ----- DERIVED ATOMS -----
+export const compareStringsState = atom(get => {
+  const { state1, state2 } = get(compareStates);
+  return [JSON.stringify(state1), JSON.stringify(state2)];
+});
+export const isDiffOpenState = atom(get => {
+  const { state1, state2 } = get(compareStates);
+  return !!(state1 || state2);
+});

--- a/src/components/T1Tabs.tsx
+++ b/src/components/T1Tabs.tsx
@@ -3,7 +3,7 @@ import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import type { Theme } from "@mui/system/createTheme";
 import type { SxProps } from "@mui/system/styleFunctionSx";
-import { atom, useAtom, useSetAtom, WritableAtom } from "jotai";
+import { atom, useAtom, WritableAtom } from "jotai";
 import {
   AriaAttributes,
   Children,
@@ -16,8 +16,6 @@ import {
   useRef,
 } from "react";
 import { joinSx } from "../utils/reactUtils";
-import { stateDiffOpen, compareStates } from "../atoms/simulationPageAtoms";
-import CloseDiff from "./simulation/CloseDiff";
 
 type TabAtom = WritableAtom<string | undefined, string, void>;
 
@@ -29,6 +27,7 @@ export type IT1TabsProps = AriaAttributes & {
   ContentContainer?: ComponentType<PropsWithChildren>;
   className?: string;
   sx?: SxProps<Theme>;
+  right?: ReactNode;
 };
 
 export function T1Tabs(props: IT1TabsProps) {
@@ -38,14 +37,13 @@ export function T1Tabs(props: IT1TabsProps) {
     className = "",
     sx,
     ContentContainer = ({ children }) => <>{children}</>,
+    right,
     ...rest
   } = props;
 
   const atomless = useRef<TabAtom | undefined>();
   let [current, setCurrent] = useWithAtom(atomless, withAtom);
   current = current || getFirstTab(children);
-  const [isDiffOpen, setIsDiffOpen] = useAtom(stateDiffOpen);
-  const setCompareStates = useSetAtom(compareStates);
   const tabs: ReactElement[] = [];
   let content: ReactNode = null;
 
@@ -92,17 +90,7 @@ export function T1Tabs(props: IT1TabsProps) {
         >
           {tabs}
         </Tabs>
-        {isDiffOpen && current === "State" && (
-          <CloseDiff
-            onClick={() => {
-              setIsDiffOpen(false);
-              setCompareStates({
-                state1: {},
-                state2: {},
-              });
-            }}
-          />
-        )}
+        {right}
       </Grid>
       <Grid item flex={1} className="T1Tabs-content">
         <ContentContainer>{content}</ContentContainer>

--- a/src/components/simulation/CloseDiff.tsx
+++ b/src/components/simulation/CloseDiff.tsx
@@ -1,13 +1,26 @@
 import CancelSharpIcon from "@mui/icons-material/CancelSharp";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
-import React from "react";
+import { useSetAtom } from "jotai";
+import React, { MouseEvent, useCallback } from "react";
+import { compareStates } from "../../atoms/simulationPageAtoms";
 
 interface IProps {
   onClick?(): void;
 }
 
-const CloseDiff = ({ onClick }: IProps) => {
+const CloseDiff = ({ onClick: _onClick }: IProps) => {
+  const setCompareStates = useSetAtom(compareStates);
+  
+  const onClick = useCallback((e: MouseEvent) => {
+    if (!e.isDefaultPrevented()) {
+      setCompareStates({
+        state1: undefined,
+        state2: undefined,
+      });
+    }
+  }, [_onClick]);
+  
   return (
     <Tooltip placement="top" title="Close compare states">
       <IconButton onClick={onClick}>

--- a/src/components/simulation/StateRenderer.tsx
+++ b/src/components/simulation/StateRenderer.tsx
@@ -1,13 +1,14 @@
 import styled from "@mui/material/styles/styled";
-import { Grid, Typography } from "@mui/material";
+import { Grid } from "@mui/material";
 import { useAtomValue } from "jotai";
 import React, { PropsWithChildren } from "react";
-import { stepTraceState } from "../../atoms/simulationPageAtoms";
+import { isDiffOpenState, stepTraceState } from "../../atoms/simulationPageAtoms";
 import T1Container from "../grid/T1Container";
 import { T1Tab, T1Tabs } from "../T1Tabs";
 import { LogsTab, ResponseTab, SummaryTab } from "./InspectorTabs";
 import { StateTab } from "./StateTab";
 import QueryTab from "./QueryTab";
+import CloseDiff from "./CloseDiff";
 
 interface IProps {
   contractAddress: string;
@@ -15,6 +16,7 @@ interface IProps {
 
 export const StateRenderer = ({ contractAddress }: IProps) => {
   const stepTrace = useAtomValue(stepTraceState);
+  const isDiffOpen = useAtomValue(isDiffOpenState);
 
   return (
     <Grid container height="100%" gap={1}>
@@ -32,7 +34,10 @@ export const StateRenderer = ({ contractAddress }: IProps) => {
         </T1Tabs>
       </Half>
       <Half>
-        <T1Tabs ContentContainer={Content}>
+        <T1Tabs
+          ContentContainer={Content}
+          right={isDiffOpen && <CloseDiff />}
+        >
           <T1Tab label="State">
             <StateTab />
           </T1Tab>

--- a/src/components/simulation/StateTab.tsx
+++ b/src/components/simulation/StateTab.tsx
@@ -1,38 +1,46 @@
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import ReactDiffViewer from "@terran-one/react-diff-viewer";
-import { useAtomValue, useAtom } from "jotai";
-import React, { useEffect } from "react";
+import { useAtomValue } from "jotai";
+import React from "react";
 import {
   blockState,
-  compareStates,
-  stateDiffOpen,
+  compareStringsState,
+  isDiffOpenState,
 } from "../../atoms/simulationPageAtoms";
 import T1JsonTree from "../T1JsonTree";
-import CloseDiff from "./CloseDiff";
 
 export interface IStateTabProps {}
 
 export const StateTab = ({}: IStateTabProps) => {
-  const compareStateObj = useAtomValue(compareStates);
+  const isDiff = useAtomValue(isDiffOpenState);
+  const [state1, state2] = useAtomValue(compareStringsState);
   const currentJSON = useAtomValue(blockState);
-  const [isDiff, setIsDiff] = useAtom(stateDiffOpen);
-  useEffect(() => {
-    setIsDiff(
-      Object.keys(compareStateObj.state1).length !== 0 &&
-        Object.keys(compareStateObj.state2).length !== 0
-    );
-  }, [compareStateObj]);
+  console.log(state1, state2)
 
   if (isDiff) {
-    return (
-      <Box>
-        <ReactDiffViewer
-          oldValue={JSON.stringify(compareStateObj.state1)}
-          newValue={JSON.stringify(compareStateObj.state2)}
-          splitView={false}
-        />
-      </Box>
-    );
+    if (state1 === state2) {
+      return (
+        <Typography
+          variant="body2"
+          fontStyle="italic"
+          color="GrayText"
+          textAlign="center"
+        >
+          No difference between selected states.
+        </Typography>
+      );
+    } else {
+      return (
+        <Box>
+          <ReactDiffViewer
+            oldValue={JSON.stringify(state1)}
+            newValue={JSON.stringify(state2)}
+            splitView={false}
+          />
+        </Box>
+      );
+    }
   } else {
     return <T1JsonTree data={currentJSON ?? {}} />;
   }


### PR DESCRIPTION
## Description
Please don't add overly specific code that only applies to exactly 1 tab out of 6 to a general purpose component.

## Test Steps
1. Create new simulation
2. Execute something
3. Compare states. It should still look & work as before.
