### PR TITLE
MouseAwayListener (Polish)

### DIFF
--- a/src/components/MouseAwayListener.tsx
+++ b/src/components/MouseAwayListener.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, Ref, SyntheticEvent, useEffect, useRef } from "react";
-import { isChildOf } from "src/utils/reactUtils";
-import { Falsy } from "../utils/typeUtils";
+import { isChildOf } from "../utils/reactUtils";
 
 export interface IMouseAwayListenerProps {
   children?: ReactElement<{ ref: Ref<HTMLElement> }>;

--- a/src/components/MouseAwayListener.tsx
+++ b/src/components/MouseAwayListener.tsx
@@ -1,0 +1,65 @@
+import React, { ReactElement, Ref, SyntheticEvent, useEffect, useRef } from "react";
+import { isChildOf } from "src/utils/reactUtils";
+import { Falsy } from "../utils/typeUtils";
+
+export interface IMouseAwayListenerProps {
+  children?: ReactElement<{ ref: Ref<HTMLElement> }>;
+  onMouseAway?(e: SyntheticEvent): void;
+}
+
+export default function MouseAwayListener({ children, onMouseAway }: IMouseAwayListenerProps) {
+  const ref = useRef<HTMLElement | null>(null);
+  
+  useEffect(() => {
+    const eventTypes = [
+      'mousemove', 'click',
+      'touchend', 'touchmove',
+    ] as const;
+    
+    const listener = (e: MouseEvent | TouchEvent) => {
+      const target = e.target as HTMLElement;
+      const synth = createEvent(e);
+      
+      if (!eventTypes.includes(e.type as any)) {
+        console.warn(`Unexpected event type ${e.type}`);
+      }
+      
+      if (ref.current && !isChildOf(ref.current, target, e.type === 'click')) {
+        onMouseAway?.(synth);
+      }
+    };
+    
+    eventTypes.forEach(
+      type => document.addEventListener(type, listener)
+    );
+    
+    return () => {
+      eventTypes.forEach(
+        type => document.removeEventListener(type, listener)
+      );
+    }
+  }, [onMouseAway]);
+  
+  if (!children) return null;
+  return <>{React.cloneElement(children, {ref})}</>
+}
+
+const createEvent = (native: Event): SyntheticEvent => ({
+  type: 'mouseaway',
+  bubbles: false,
+  cancelable: false,
+  target: native.target!,
+  currentTarget: native.currentTarget as Element,
+  defaultPrevented: false,
+  isDefaultPrevented: () => false,
+  isPropagationStopped: () => false,
+  isTrusted: false,
+  eventPhase: 0,
+  nativeEvent: native,
+  persist() {},
+  preventDefault() {
+    this.defaultPrevented = true;
+  },
+  stopPropagation() {},
+  timeStamp: Date.now(),
+});

--- a/src/components/T1Popover.tsx
+++ b/src/components/T1Popover.tsx
@@ -1,62 +1,65 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useId, useState } from "react";
 import { Box, Popover, Typography } from "@mui/material";
 import { Info } from "@mui/icons-material";
+import MouseAwayListener from "./MouseAwayListener";
 
 export interface IPopoverProps {
   children?: ReactNode;
-  text: string;
+  text: ReactNode;
 }
 
 function T1Popover({children, text}: IPopoverProps) {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-
-  const handlePopoverOpen = (event: any) => {
-    setAnchorEl(event.currentTarget);
+  const id = useId();
+  const [anchorEl, setAnchorEl] = useState<SVGSVGElement | null>(null);
+  const [open, setOpen] = useState(false);
+  
+  const handlePopoverOpen = () => {
+    setOpen(true);
   };
 
   const handlePopoverClose = () => {
-    setAnchorEl(null);
+    setOpen(false);
   };
 
-  // @ts-ignore
-  const open = Boolean(anchorEl);
-
   return (
-    <Box flexDirection='row'
-         sx={{
-           alignItems: 'center',
-           display: 'flex',
-           textAlign: 'center',
-           justifyContent: 'center'
-         }}>
-      {children}
-      <Info
-        sx={{fontSize: '1.2rem', ml: 0.5, pb: 0.2}}
-        aria-owns={open ? 'mouse-over-popover' : undefined}
-        aria-haspopup="true"
-        onMouseEnter={handlePopoverOpen}
-        onMouseLeave={handlePopoverClose}/>
-      <Popover
-        id="mouse-over-popover"
-        sx={{
-          pointerEvents: 'none',
-        }}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'center',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        onClose={handlePopoverClose}
-        disableRestoreFocus
-      >
-        <Typography sx={{p: 1}}>{text}</Typography>
-      </Popover>
-    </Box>
+    <MouseAwayListener onMouseAway={handlePopoverClose}>
+      <Box flexDirection='row'
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            textAlign: 'center',
+            justifyContent: 'center'
+          }}>
+        {children}
+        <Info
+          ref={setAnchorEl}
+          sx={{fontSize: '1.2rem', ml: 0.5, pb: 0.2}}
+          aria-owns={open ? id : undefined}
+          aria-haspopup="true"
+          onMouseEnter={handlePopoverOpen}
+        />
+        <Popover
+          id={id}
+          sx={{
+            pointerEvents: 'none',
+          }}
+          open={open}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          onClose={handlePopoverClose}
+          disableRestoreFocus
+        >
+          <Typography sx={{p: 1}}>{text}</Typography>
+        </Popover>
+      </Box>
+    </MouseAwayListener>
   )
 }
 

--- a/src/utils/reactUtils.ts
+++ b/src/utils/reactUtils.ts
@@ -14,3 +14,11 @@ export function joinSx<T extends {}>(...sxs: (SxProps<T> | Falsy)[]): SxProps<T>
   }
   return result;
 }
+
+export function isChildOf(root: HTMLElement, child: HTMLElement | Falsy, log = false): boolean {
+  let curr = child;
+  while (curr && curr !== root) {
+    curr = curr.parentElement;
+  }
+  return curr === root;
+}


### PR DESCRIPTION
## Description
Adds `MouseAwayListener` which fulfills a similar purpose to MUI's `ClickAwayListener`

Reason: `onMouseLeave` event is not guaranteed to fire, e.g. if the user tabs out, moves mouse, and tabs back in. `MouseAwayListener` allows us to catch this case anyways.

## Test steps
1. Create simulation & instantiate contract
2. Mouse over contract address' info icon
3. Popover appears and disappears properly
