### PR TITLE
Feat/no errored state comp

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
   <meta content="width=device-width, initial-scale=1" name="viewport"/>
   <meta content="#000000" name="theme-color"/>
   <meta
-    content="Web site created using create-react-app"
+    content="Simulator & Debugger for CosmWasm Smart Contracts"
     name="description"
   />
   <link href="%PUBLIC_URL%/T1.svg" rel="apple-touch-icon"/>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,20 +1,20 @@
 {
-  "short_name": "CW Debug",
-  "name": "CW Debugger",
+  "short_name": "CW Sim",
+  "name": "CW Simulate",
   "icons": [
     {
       "src": "T1.svg",
       "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
+      "type": "image/svg"
     },
     {
       "src": "T1.svg",
-      "type": "image/png",
+      "type": "image/svg",
       "sizes": "192x192"
     },
     {
       "src": "T1.svg",
-      "type": "image/png",
+      "type": "image/svg",
       "sizes": "512x512"
     }
   ],

--- a/src/components/JsonCodeMirrorEditor.tsx
+++ b/src/components/JsonCodeMirrorEditor.tsx
@@ -25,7 +25,7 @@ export const JsonCodeMirrorEditor = ({
     JSON: "Enter your JSON here",
   };
 
-  const [validationError, setValidationError] = useState('');
+  const [validationError, setValidationError] = useState("");
   const theme = useTheme();
 
   return (
@@ -51,16 +51,19 @@ export const JsonCodeMirrorEditor = ({
                 if (!validateJSON(parsedJSON, {})) {
                   //TODO: Show correct error message when validate message functionality changes.
                   setValidationError("Invalid JSON");
+                  onValidate?.(false);
                 } else {
+                  onValidate?.(true);
                   setValidationError("");
                 }
               } catch {
                 setValidationError("Invalid JSON");
+                onValidate?.(false);
               }
             }}
             theme={theme.palette.mode}
             placeholder={JSON.stringify(defaultPlaceholder, null, 2)}
-            style={{border: "none", height: "100%"}}
+            style={{ border: "none", height: "100%" }}
           />
         </T1Container>
       </Grid>

--- a/src/components/simulation/StateStepper.tsx
+++ b/src/components/simulation/StateStepper.tsx
@@ -261,7 +261,11 @@ function renderTreeItems(
             />
           }
           labelText={getTreeItemLabel(trace)}
-          activeStep={depth === 0 ? activeStep : undefined}
+          activeStep={
+            depth === 0 && !(trace.response as MaybeError).error
+              ? activeStep
+              : undefined
+          }
         />
       );
     } else {
@@ -277,7 +281,11 @@ function renderTreeItems(
             />
           }
           labelText={getTreeItemLabel(trace)}
-          activeStep={depth === 0 ? activeStep : undefined}
+          activeStep={
+            depth === 0 && !(trace.response as MaybeError).error
+              ? activeStep
+              : undefined
+          }
         >
           {renderTreeItems(
             trace.trace,


### PR DESCRIPTION
## Issue link

(https://trello.com/c/h9yFQMed/82-dont-show-state-diff-for-error-state)
(https://trello.com/c/J8oCJDcf/89-disable-run-button-when-json-is-invalid)

## Description
1) Removed burger menu from errored steps so you can't do state diff for errored steps now.
2) Disabled Run button for invalid JSONs in JSON editor of Execute/Query
## Test steps

1. Go to simulation page.
2. Perform some executions with wrong messages and now you see there is no burger menu for errored steps.
3. Also, type in invalid JSON in editors and see Run button getting disabled, and then enabled again when you correct your JSON.
