### PR TITLE
Prevent adding empty accounts

### DIFF
--- a/src/CWSimulationBridge.ts
+++ b/src/CWSimulationBridge.ts
@@ -239,7 +239,7 @@ export default class CWSimulationBridge {
 
 export function useAccounts(bridge: CWSimulationBridge) {
   return bridge.useWatcher(
-    app => app.bank.getBalances().toObject(),
+    app => app.bank.getBalances().toObject() ?? {},
     compareShallowObject,
   );
 }

--- a/src/components/Funds.tsx
+++ b/src/components/Funds.tsx
@@ -11,6 +11,7 @@ export interface IFundsProps {
   text?: ReactNode;
   TextComponent?: ComponentType<PropsWithChildren<{ sx?: SxProps<Theme> }>>;
   hideError?: boolean;
+  defaultValue?: string;
   onChange?(funds: Coin[]): void;
   onValidate?(valid: boolean): void;
   sx?: SxProps<Theme>;
@@ -21,6 +22,7 @@ export default function Funds(props: IFundsProps) {
     TextComponent = Typography,
     text,
     hideError,
+    defaultValue,
     onChange,
     onValidate,
     ...boxProps
@@ -51,6 +53,7 @@ export default function Funds(props: IFundsProps) {
         inputRef={ref}
         label="Funds"
         onKeyUp={update}
+        defaultValue={defaultValue}
         placeholder={'1000 uluna, 4000 uust, ...'}
         sx={{width: '100%'}}
       />

--- a/src/components/chains/Accounts.tsx
+++ b/src/components/chains/Accounts.tsx
@@ -9,41 +9,30 @@ import {
   ListItemIcon,
   ListItemText,
   MenuItem,
+  TextField,
   Typography,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { Coin } from "@terran-one/cw-simulate/dist/types";
-import React, { useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { useNotification } from "../../atoms/snackbarNotificationState";
 import { defaults } from "../../configs/constants";
-import useSimulation from "../../hooks/useSimulation";
 import { useAccounts } from "../../CWSimulationBridge";
-import { validateAccountJSON } from "../../utils/fileUtils";
+import useSimulation from "../../hooks/useSimulation";
+import { stringifyFunds } from "../../utils/typeUtils";
 import T1Container from "../grid/T1Container";
-import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import TableLayout from "./TableLayout";
+import Funds from "../Funds";
 
-const getDefaultAccount = (chainId: string) => {
-  const result = Object.entries(defaults.chains).map(([_, config]) => {
-    if (config.chainId === chainId) {
-      return {sender: config.sender, "coins": config.funds};
-    }
-  }).filter((x) => x !== undefined)[0];
-
-  return JSON.stringify(result, null, 2);
-}
+const getDefaultAccount = (chainId: string) =>
+  Object.values(defaults.chains).find(config => config.chainId === chainId) ?? defaults.chains.terra;
 
 const Accounts = () => {
   const sim = useSimulation();
-  const accounts = Object.entries(useAccounts(sim) ?? {});
+  const accounts = Object.entries(useAccounts(sim));
   const setNotification = useNotification();
 
-  const [openDialog, setOpenDialog] = useState(false);
-  const [payload, setPayload] = useState(getDefaultAccount(sim.chainId));
-  const handleClickOpen = () => {
-    setOpenDialog(true);
-    setPayload(getDefaultAccount(sim.chainId));
-  };
+  const [openAddDialog, setOpenAddDialog] = useState(false);
 
   const data = accounts.map(([address, balances]) => {
     return {
@@ -51,30 +40,6 @@ const Accounts = () => {
       balances: balances.map((c: Coin) => `${c.amount} ${c.denom}`).join(", "),
     };
   });
-
-  const handleClose = () => {
-    setOpenDialog(false);
-  };
-
-  const handleAddAccount = () => {
-    const json = JSON.parse(payload);
-
-    if (payload.length === 0 || !validateAccountJSON(json)) {
-      setNotification("Invalid Account JSON", {severity: "error"});
-      return;
-    }
-
-    if (accounts.find((acc: [string, Coin[]]) => acc[0] === json.sender)) {
-      setNotification("An account with this address already exists", {
-        severity: "error",
-      });
-      return;
-    }
-
-    sim.setBalance(json.sender, json.coins);
-    setNotification("Account added successfully");
-    setOpenDialog(false);
-  };
 
   const handleDeleteAccount = (address: string) => {
     setNotification("Account successfully removed");
@@ -87,7 +52,7 @@ const Accounts = () => {
           <Typography variant="h6">Accounts</Typography>
         </Grid>
         <Grid item>
-          <Button variant="contained" onClick={handleClickOpen}>
+          <Button variant="contained" onClick={() => setOpenAddDialog(true)}>
             New Account
           </Button>
         </Grid>
@@ -116,26 +81,83 @@ const Accounts = () => {
           />
         </T1Container>
       </Grid>
-      <Dialog open={openDialog} onClose={handleClose}>
-        <DialogTitle>Add New Account</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Enter account address and balance.
-          </DialogContentText>
-          <T1Container sx={{width: 400, height: 220}}>
-            <JsonCodeMirrorEditor
-              jsonValue={getDefaultAccount(sim.chainId)}
-              onChange={setPayload}
-            />
-          </T1Container>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleClose}>Cancel</Button>
-          <Button onClick={handleAddAccount}>Add</Button>
-        </DialogActions>
-      </Dialog>
+      <AddAccountDialog open={openAddDialog} onClose={() => setOpenAddDialog(false)} />
     </>
   );
 };
 
 export default Accounts;
+
+interface DialogProps {
+  open: boolean;
+  onClose(): void;
+}
+
+function AddAccountDialog({ open, onClose }: DialogProps) {
+  const sim = useSimulation();
+  const accounts = Object.entries(useAccounts(sim));
+  const defaultAccount = getDefaultAccount(sim.chainId);
+  
+  const refAddress = useRef<HTMLInputElement | null>(null);
+  const [address, setAddress] = useState(defaultAccount.sender);
+  const [funds, setFunds] = useState<Coin[]>(defaultAccount.funds);
+  const [isFundsValid, setFundsValid] = useState(true);
+  
+  const setNotification = useNotification();
+  
+  const handleChangeAddress = useCallback(() => {
+    if (refAddress.current)
+      setAddress(refAddress.current.value)
+  }, []);
+  
+  const addAccount = useCallback(() => {
+    if (!funds.length) {
+      setNotification('Please specify funds for the new account.', { severity: 'error' });
+      return;
+    }
+    
+    if (!isFundsValid) {
+      setNotification('Invalid funds. Please see the message underneath funds input.', { severity: 'error' });
+      return;
+    }
+    
+    if (accounts.find(([addr]) => addr === address)) {
+      setNotification('An account with this address already exists', { severity: 'error' });
+      return;
+    }
+
+    sim.setBalance(address, funds);
+    setNotification("Account added successfully");
+    onClose();
+  }, [accounts, address, funds, isFundsValid]);
+  
+  const valid = isFundsValid && !!funds.length;
+  
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Add New Account</DialogTitle>
+      <DialogContent sx={{ minWidth: 380 }}>
+        <TextField
+          inputRef={refAddress}
+          label="Address"
+          defaultValue={defaultAccount.sender}
+          onChange={handleChangeAddress}
+          sx={{ width: '100%', my: 2 }}
+        />
+        <Funds
+          onChange={setFunds}
+          onValidate={setFundsValid}
+          hideError={!funds.length}
+          defaultValue={stringifyFunds(defaultAccount.funds)}
+        />
+        {!funds.length && <DialogContentText color="red" fontStyle="italic">Please enter funds.</DialogContentText>}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={addAccount} disabled={!valid}>
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Issue link
https://trello.com/c/QOjTkwUQ/80-create-funds-take-empty-coins

## Description
Prevents users from adding accounts with empty funds. Also, replace JSON code mirror with two dedicated input fields, reusing `<Funds />` component

## Test steps
1. Create a new simulation
2. Begin adding account
3. Remove funds - red text should appear instructing to add funds, and Add button should become disabled
4. Add proper funds - red text should disappear, and button becomes re-enabled
