### PR TITLE
Fixed inspector and query tab.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.2",
         "react-flow-renderer": "^10.3.17",
-        "react-inspector": "^6.0.1",
         "react-json-tree": "^0.17.0",
         "react-object-table-viewer": "^1.0.7",
         "react-router-dom": "^6.4.1",
@@ -28146,14 +28145,6 @@
         "react-dom": "16 || 17 || 18"
       }
     },
-    "node_modules/react-inspector": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.1.tgz",
-      "integrity": "sha512-cxKSeFTf7jpSSVddm66sKdolG90qURAX3g1roTeaN6x0YEbtWc8JpmFN9+yIqLNH2uEkYerWLtJZIXRIFuBKrg==",
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -53769,12 +53760,6 @@
         "d3-zoom": "^3.0.0",
         "zustand": "^3.7.2"
       }
-    },
-    "react-inspector": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.1.tgz",
-      "integrity": "sha512-cxKSeFTf7jpSSVddm66sKdolG90qURAX3g1roTeaN6x0YEbtWc8JpmFN9+yIqLNH2uEkYerWLtJZIXRIFuBKrg==",
-      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.2",
     "react-flow-renderer": "^10.3.17",
-    "react-inspector": "^6.0.1",
     "react-json-tree": "^0.17.0",
     "react-object-table-viewer": "^1.0.7",
     "react-router-dom": "^6.4.1",

--- a/src/components/CollapsibleWidget.tsx
+++ b/src/components/CollapsibleWidget.tsx
@@ -16,6 +16,7 @@ export interface ICollabsibleWidgetProps {
   maxHeight?: number;
   children?: ReactNode;
   sx?: SxProps<Theme>;
+  isCollapsible?: boolean;
 }
 
 function CollapsibleWidget({
@@ -26,6 +27,7 @@ function CollapsibleWidget({
   maxHeight,
   children,
   sx,
+  isCollapsible = true,
 }: ICollabsibleWidgetProps) {
   const theme = useTheme();
   const expanded = collapsed === undefined ? true : collapsed;
@@ -36,7 +38,7 @@ function CollapsibleWidget({
   }, [collapsed]);
 
   return (
-    <Box sx={joinSx({borderRadius: 1, overflow: "hidden", pb: 0.5}, sx)}>
+    <Box sx={joinSx({ borderRadius: 1, overflow: "hidden", pb: 0.5 }, sx)}>
       <Box
         sx={{
           display: "flex",
@@ -47,15 +49,13 @@ function CollapsibleWidget({
           py: 0.5,
           px: 1,
         }}
-        onClick={() => setShow((curr) => !curr)}
+        onClick={isCollapsible ? () => setShow((curr) => !curr) : undefined}
       >
-        <CollapsibleIcon expanded={show}/>
-        <Typography sx={{fontSize: "1.1rem"}}>{title}</Typography>
+        {isCollapsible && <CollapsibleIcon expanded={show} />}
+        <Typography sx={{ fontSize: "1.1rem" }}>{title}</Typography>
       </Box>
       <Collapse in={show}>
-        <Box sx={{minHeight, maxHeight, height}}>
-          {children}
-        </Box>
+        <Box sx={{ minHeight, maxHeight, height }}>{children}</Box>
       </Collapse>
     </Box>
   );

--- a/src/components/simulation/tabs/LogsTab.tsx
+++ b/src/components/simulation/tabs/LogsTab.tsx
@@ -6,14 +6,8 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import { TraceLog } from "@terran-one/cw-simulate";
-import { chromeDark } from "react-inspector";
 import T1JsonTree from "../../T1JsonTree";
 import { EmptyTab, IInspectorTabProps } from "./Common";
-
-const INSPECTOR_THEME: any = {
-  ...chromeDark,
-  BASE_BACKGROUND_COLOR: "transparent",
-};
 
 export default function LogsTab({ traceLog }: IInspectorTabProps) {
   if (!traceLog) return <EmptyTab />;

--- a/src/components/simulation/tabs/LogsTab.tsx
+++ b/src/components/simulation/tabs/LogsTab.tsx
@@ -1,11 +1,13 @@
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useTheme } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 import { TraceLog } from "@terran-one/cw-simulate";
-import { chromeDark, ObjectInspector } from "react-inspector";
+import { chromeDark } from "react-inspector";
+import T1JsonTree from "../../T1JsonTree";
 import { EmptyTab, IInspectorTabProps } from "./Common";
 
 const INSPECTOR_THEME: any = {
@@ -13,13 +15,13 @@ const INSPECTOR_THEME: any = {
   BASE_BACKGROUND_COLOR: "transparent",
 };
 
-export default function LogsTab({traceLog}: IInspectorTabProps) {
-  if (!traceLog) return <EmptyTab />
+export default function LogsTab({ traceLog }: IInspectorTabProps) {
+  if (!traceLog) return <EmptyTab />;
 
   let combinedLogs = combineLogs(traceLog).filter((log) => log.type === "call");
 
   return (
-    <Grid sx={{height: "100%", width: "100%"}}>
+    <Grid sx={{ height: "100%", width: "100%" }}>
       {combinedLogs.length === 0 ? (
         <Grid
           sx={{
@@ -34,49 +36,67 @@ export default function LogsTab({traceLog}: IInspectorTabProps) {
         </Grid>
       ) : (
         combinedLogs.map((log, index) => (
-          <CallListItem ix={index} key={`a-${index}`} call={log}/>
+          <CallListItem
+            ix={index}
+            key={`a-${index}`}
+            call={log}
+            islastItem={index === combinedLogs.length - 1}
+          />
         ))
       )}
     </Grid>
   );
-};
+}
 
 const CallListItem = ({
   call,
   ix,
+  islastItem,
 }: {
   call: { args: { [k: string]: any }; result: any; fn: string };
   ix: number;
+  islastItem: boolean;
 }) => {
+  const theme = useTheme();
   return (
-    <Accordion>
+    <Accordion
+      sx={{
+        "&.Mui-expanded": {
+          margin: "0px",
+          borderBottom: !islastItem ? "1px solid #bccabc" : "",
+        },
+      }}
+    >
       <AccordionSummary
-        expandIcon={<ExpandMoreIcon/>}
+        expandIcon={<ExpandMoreIcon />}
         aria-controls="panel1a-content"
         id="panel1a-header"
       >
         <Typography
           fontFamily={"JetBrains Mono"}
-          sx={{wordWrap: "break-word"}}
+          sx={{ wordWrap: "break-word" }}
         >
           [{ix}] {call.fn}
         </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        <table style={{wordBreak: "break-word"}}>
-          <ObjectInspector
-            theme={INSPECTOR_THEME}
-            data={call.args}
-            style={{backgroundColor: "transparent"}}
-          />
+        <table style={{ wordBreak: "break-word" }}>
+          <T1JsonTree data={call.args} />
         </table>
-        <h4>Result</h4>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontWeight: "bold", mt: 1, mb: 1 }}
+        >
+          Result
+        </Typography>
         {call.result ? (
-          <Typography variant="body2" sx={{wordBreak: "break-word"}}>
-            {JSON.stringify(call.result, null, 2)}
+          <Typography variant="body2" sx={{ wordBreak: "break-word" }}>
+            {call.result}
           </Typography>
         ) : (
-          <Typography variant="body2">None</Typography>
+          <Typography variant="body2" color={theme.palette.grey[600]}>
+            None
+          </Typography>
         )}
       </AccordionDetails>
     </Accordion>

--- a/src/components/simulation/tabs/LogsTab.tsx
+++ b/src/components/simulation/tabs/LogsTab.tsx
@@ -34,7 +34,7 @@ export default function LogsTab({ traceLog }: IInspectorTabProps) {
             ix={index}
             key={`a-${index}`}
             call={log}
-            islastItem={index === combinedLogs.length - 1}
+            isLastItem={index === combinedLogs.length - 1}
           />
         ))
       )}
@@ -45,11 +45,11 @@ export default function LogsTab({ traceLog }: IInspectorTabProps) {
 const CallListItem = ({
   call,
   ix,
-  islastItem,
+  isLastItem,
 }: {
   call: { args: { [k: string]: any }; result: any; fn: string };
   ix: number;
-  islastItem: boolean;
+  isLastItem: boolean;
 }) => {
   const theme = useTheme();
   return (
@@ -57,7 +57,7 @@ const CallListItem = ({
       sx={{
         "&.Mui-expanded": {
           margin: "0px",
-          borderBottom: !islastItem ? "1px solid #bccabc" : "",
+          borderBottom: !isLastItem ? "1px solid #bccabc" : "",
         },
       }}
     >

--- a/src/components/simulation/tabs/QueryTab.tsx
+++ b/src/components/simulation/tabs/QueryTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { JsonCodeMirrorEditor } from "../../JsonCodeMirrorEditor";
 import { useNotification } from "../../../atoms/snackbarNotificationState";
-import { Button, Grid, Typography, useTheme } from "@mui/material";
+import { Button, Grid } from "@mui/material";
 import T1Container from "../../grid/T1Container";
 import useSimulation from "../../../hooks/useSimulation";
 import Divider from "@mui/material/Divider";
@@ -24,7 +24,6 @@ export default function QueryTab({ contractAddress }: IProps) {
   const onHandleQuery = (res: Result<any, string>) => {
     setResponse(res);
   };
-  const theme = useTheme();
   return (
     <Grid
       item

--- a/src/components/simulation/tabs/QueryTab.tsx
+++ b/src/components/simulation/tabs/QueryTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { JsonCodeMirrorEditor } from "../../JsonCodeMirrorEditor";
 import { useNotification } from "../../../atoms/snackbarNotificationState";
-import { Button, Grid } from "@mui/material";
+import { Button, Grid, Typography, useTheme } from "@mui/material";
 import T1Container from "../../grid/T1Container";
 import useSimulation from "../../../hooks/useSimulation";
 import Divider from "@mui/material/Divider";
@@ -11,7 +11,7 @@ import { useAtomValue } from "jotai";
 import { activeStepState } from "../../../atoms/simulationPageAtoms";
 import { getFormattedStep } from "../Executor";
 import { Result } from "ts-results/result";
-import { TabHeader } from "./Common";
+import { EmptyTab, TabHeader } from "./Common";
 import BlockQuote from "../../BlockQuote";
 
 interface IProps {
@@ -24,7 +24,7 @@ export default function QueryTab({ contractAddress }: IProps) {
   const onHandleQuery = (res: Result<any, string>) => {
     setResponse(res);
   };
-
+  const theme = useTheme();
   return (
     <Grid
       item
@@ -39,6 +39,7 @@ export default function QueryTab({ contractAddress }: IProps) {
       <CollapsibleWidget
         title={`Query @${getFormattedStep(activeStep)}`}
         height={280}
+        isCollapsible={false}
       >
         <Query
           contractAddress={contractAddress}
@@ -53,8 +54,10 @@ export default function QueryTab({ contractAddress }: IProps) {
               <TabHeader>Query Error</TabHeader>
               <BlockQuote>{response.val}</BlockQuote>
             </>
-          ) : (
+          ) : response ? (
             <T1JsonTree data={response?.val} />
+          ) : (
+            <EmptyTab>Your query output will appear here</EmptyTab>
           )}
         </T1Container>
       </Grid>

--- a/src/components/simulation/tabs/StateTab.tsx
+++ b/src/components/simulation/tabs/StateTab.tsx
@@ -20,7 +20,7 @@ export const StateTab = ({}: IStateTabProps) => {
 
   if (isDiff) {
     if (compareDeep(state1, state2)) {
-      return <EmptyTab>No difference between selected states.</EmptyTab>
+      return <EmptyTab>No difference between selected states.</EmptyTab>;
     }
     return (
       <Box>
@@ -32,7 +32,7 @@ export const StateTab = ({}: IStateTabProps) => {
       </Box>
     );
   } else {
-    if (!currentJSON) return <EmptyTab />
+    if (!currentJSON) return <EmptyTab />;
     return <T1JsonTree data={currentJSON} />;
   }
 };


### PR DESCRIPTION
## Issue link

https://trello.com/c/kzIN77OT/58-uniform-styling-across-simulation-screen

## Description
Fixed couple of issues related to json tree view in logs section, also the output for query. Leaving accordion as it is as of now.

## Test steps

1. Go to simulation page. Perform some executions.
2. Go to Logs tab, expand accordion there should be json tree view now.
3. Go to query tab, it's not collapsible anymore.
4. There is a placeholder for empty query response.
