### PR TITLE
Query is now querrying from selected chain snapshot and not the current state

### DIFF
--- a/src/CWSimulationBridge.ts
+++ b/src/CWSimulationBridge.ts
@@ -4,6 +4,7 @@ import { CodeInfo, Coin, ContractInfo, CWSimulateApp, CWSimulateAppOptions, Trac
 import { Map } from "immutable";
 import { DependencyList, useEffect, useReducer } from "react";
 import { defaults } from "./configs/constants";
+import { getStepTrace } from "./utils/commonUtils";
 
 declare module "@terran-one/cw-simulate" {
   class CodeInfo {
@@ -192,10 +193,10 @@ export default class CWSimulationBridge {
     return result;
   }
 
-  async query(contractAddress: string, msg: any) {
+  async query(contractAddress: string, msg: any, step:string) {
     const info = this.getContract(contractAddress);
     if (!info) throw new Error(`No such contract with address ${contractAddress}`);
-    return await this.app.wasm.query(contractAddress, msg);
+    return await this.app.wasm.queryTrace(getStepTrace(step, info.trace),msg);
   }
 
   sync() {

--- a/src/components/simulation/tabs/QueryTab.tsx
+++ b/src/components/simulation/tabs/QueryTab.tsx
@@ -66,9 +66,14 @@ function Query({ contractAddress, onHandleQuery }: IQuery) {
   const activeStep = useAtomValue(activeStepState);
   const [payload, setPayload] = useState("");
   const [isValid, setIsValid] = useState(true);
+
   const handleQuery = async () => {
     try {
-      const res = await sim.query(contractAddress, JSON.parse(payload));
+      const res = await sim.query(
+        contractAddress,
+        JSON.parse(payload),
+        activeStep
+      );
       onHandleQuery(res);
       if (res.err) {
         throw new Error("Something went wrong while querying.");

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -1,0 +1,12 @@
+import { TraceLog } from "@terran-one/cw-simulate";
+
+export const getStepTrace = (activeStep: string, trace: TraceLog[]) => {
+  const activeStepArr = activeStep.split("-").map((ele) => Number(ele));
+  let activeTrace: TraceLog = {} as TraceLog;
+  for (let i = 0; i < activeStepArr.length - 1; i++) {
+    activeTrace = activeTrace.trace
+      ? activeTrace.trace[activeStepArr[i]]
+      : trace[activeStepArr[i]];
+  }
+  return activeTrace;
+};


### PR DESCRIPTION
Query is now querrying from selected chain snapshot and not the current state

## Issue link

[[WL-XXX](https://terran-one.atlassian.net/browse/WL-XXX)](https://trello.com/c/nUhuNy3R/92-queries-should-query-from-selected-chain-state-snapshot-not-the-current-state)

## Description
Query is now querrying from selected chain snapshot and not the current state.

## Test steps
1. Go to simulation page.
2. Perform some executions and now query at different steps, it should query at that particular step rather than current state.
