### PR TITLE
Enabled dark mode for JSON Diff viewer.

### DIFF
--- a/src/components/simulation/tabs/StateTab.tsx
+++ b/src/components/simulation/tabs/StateTab.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../atoms/simulationPageAtoms";
 import T1JsonTree from "../../T1JsonTree";
 import { EmptyTab } from "./Common";
+import { darkModeState } from "../../../atoms/uiState";
 
 export interface IStateTabProps {}
 
@@ -17,7 +18,7 @@ export const StateTab = ({}: IStateTabProps) => {
   const isDiff = useAtomValue(isDiffOpenState);
   const [state1, state2] = useAtomValue(compareStringsState);
   const currentJSON = useAtomValue(blockState);
-
+  const darkModeEnabled = useAtomValue(darkModeState);
   if (isDiff) {
     if (compareDeep(state1, state2)) {
       return <EmptyTab>No difference between selected states.</EmptyTab>;
@@ -28,6 +29,7 @@ export const StateTab = ({}: IStateTabProps) => {
           oldValue={JSON.stringify(state1)}
           newValue={JSON.stringify(state2)}
           splitView={false}
+          useDarkTheme={darkModeEnabled}
         />
       </Box>
     );


### PR DESCRIPTION
## Issue link

[[WL-XXX](https://terran-one.atlassian.net/browse/WL-XXX)](https://trello.com/c/jC4iVaPy/71-jsondiff-in-dark-mode)

## Description
Enabled dark mode view for JSON diff viewer as well.

## Test steps

1. Go to simulation page.
2. Perform couple of executions and now checkout state diff in light as well as dark mode. It should adapt accordingly.
