### PR TITLE
Added ability to switch accounts from simulation screen. (1st cut).

### DIFF
--- a/src/components/chains/Accounts.tsx
+++ b/src/components/chains/Accounts.tsx
@@ -16,7 +16,7 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { Coin } from "@terran-one/cw-simulate/dist/types";
 import React, { useCallback, useRef, useState } from "react";
 import { useNotification } from "../../atoms/snackbarNotificationState";
-import { defaults } from "../../configs/constants";
+import { getDefaultAccount } from "../../utils/commonUtils";
 import { useAccounts } from "../../CWSimulationBridge";
 import useSimulation from "../../hooks/useSimulation";
 import { stringifyFunds } from "../../utils/typeUtils";
@@ -24,10 +24,6 @@ import T1Container from "../grid/T1Container";
 import TableLayout from "./TableLayout";
 import Funds from "../Funds";
 import Address from "./Address";
-
-const getDefaultAccount = (chainId: string) =>
-  Object.values(defaults.chains).find((config) => config.chainId === chainId) ??
-  defaults.chains.terra;
 
 const Accounts = () => {
   const sim = useSimulation();

--- a/src/components/simulation/AccountPopover.tsx
+++ b/src/components/simulation/AccountPopover.tsx
@@ -8,13 +8,23 @@ import {
   TextField,
 } from "@mui/material";
 import { Coin } from "@terran-one/cw-simulate";
+import Funds from "../Funds";
+import { stringifyFunds } from "../../utils/typeUtils";
 
 interface IProps {
   accounts: { [key: string]: Coin[] };
   account: string;
   changeAccount: (val: string) => void;
+  funds: Coin[];
+  changeFunds?(funds: Coin[]): void;
 }
-const AccountPopover = ({ account, changeAccount, accounts }: IProps) => {
+const AccountPopover = ({
+  account,
+  changeAccount,
+  accounts,
+  funds,
+  changeFunds,
+}: IProps) => {
   const [anchorEl, setAnchorEl] =
     React.useState<HTMLButtonElement | null>(null);
   const handleDiffClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -24,6 +34,7 @@ const AccountPopover = ({ account, changeAccount, accounts }: IProps) => {
     setAnchorEl(null);
   };
 
+  const [isFundsValid, setFundsValid] = useState(true);
   const open = Boolean(anchorEl);
   const id = open ? "simple-popover" : undefined;
   return (
@@ -44,6 +55,7 @@ const AccountPopover = ({ account, changeAccount, accounts }: IProps) => {
           "& .MuiPopover-paper ": {
             boxShadow: "rgba(149, 157, 165, 0.2) 0px 4px 4px !important",
             width: "20vw",
+            p: 1,
           },
           "& .MuiInputLabel-root.Mui-focused": {
             color: "#6b5f5f",
@@ -52,12 +64,18 @@ const AccountPopover = ({ account, changeAccount, accounts }: IProps) => {
       >
         <Autocomplete
           onInputChange={(_, value) => changeAccount(value)}
-          sx={{ width: "100%", padding: 1 }}
+          sx={{ width: "100%" }}
           value={account}
           renderInput={(params: AutocompleteRenderInputParams) => (
             <TextField {...params} label="Sender" />
           )}
           options={Object.keys(accounts)}
+        />
+        <Funds
+          defaultValue={stringifyFunds(funds)}
+          onChange={changeFunds}
+          onValidate={setFundsValid}
+          sx={{ mt: 2 }}
         />
       </Popover>
     </>

--- a/src/components/simulation/AccountPopover.tsx
+++ b/src/components/simulation/AccountPopover.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import AccountBalanceWalletOutlinedIcon from "@mui/icons-material/AccountBalanceWalletOutlined";
+import {
+  Autocomplete,
+  AutocompleteRenderInputParams,
+  Button,
+  Popover,
+  TextField,
+} from "@mui/material";
+import { Coin } from "@terran-one/cw-simulate";
+
+interface IProps {
+  accounts: { [key: string]: Coin[] };
+  account: string;
+  changeAccount: (val: string) => void;
+}
+const AccountPopover = ({ account, changeAccount, accounts }: IProps) => {
+  const [anchorEl, setAnchorEl] =
+    React.useState<HTMLButtonElement | null>(null);
+  const handleDiffClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleDiffClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+  return (
+    <>
+      <Button aria-describedby="abcd" onClick={handleDiffClick}>
+        <AccountBalanceWalletOutlinedIcon sx={{ color: "white" }} />
+      </Button>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleDiffClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        sx={{
+          "& .MuiPopover-paper ": {
+            boxShadow: "rgba(149, 157, 165, 0.2) 0px 4px 4px !important",
+            width: "20vw",
+          },
+          "& .MuiInputLabel-root.Mui-focused": {
+            color: "#6b5f5f",
+          },
+        }}
+      >
+        <Autocomplete
+          onInputChange={(_, value) => changeAccount(value)}
+          sx={{ width: "100%", padding: 1 }}
+          value={account}
+          renderInput={(params: AutocompleteRenderInputParams) => (
+            <TextField {...params} label="Sender" />
+          )}
+          options={Object.keys(accounts)}
+        />
+      </Popover>
+    </>
+  );
+};
+export default AccountPopover;

--- a/src/components/simulation/Executor.tsx
+++ b/src/components/simulation/Executor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import { useNotification } from "../../atoms/snackbarNotificationState";
 import { Button, Chip, Grid, Typography } from "@mui/material";
@@ -10,6 +10,8 @@ import { activeStepState } from "../../atoms/simulationPageAtoms";
 import { BeautifyJSON } from "./tabs/Common";
 import CollapsibleWidget from "../CollapsibleWidget";
 import AccountPopover from "./AccountPopover";
+import { getDefaultAccount } from "../../utils/commonUtils";
+import { Coin } from "@terran-one/cw-simulate/dist/types";
 
 interface IProps {
   contractAddress: string;
@@ -25,14 +27,15 @@ export const getFormattedStep = (step: string) => {
 export default function Executor({ contractAddress }: IProps) {
   const sim = useSimulation();
   const setNotification = useNotification();
+  const defaultAccount = getDefaultAccount(sim.chainId);
   const [payload, setPayload] = useState("");
   const [isValid, setIsValid] = useState(true);
   const accounts = useAccounts(sim);
   const [account, setAccount] = useState(Object.keys(accounts)[0]);
-  const [sender, funds] =
-    Object.entries(accounts).filter((itr) => itr[0] === account)[0] ?? [];
-  const activeStep = useAtomValue(activeStepState);
+  const [funds, setFunds] = useState<Coin[]>(defaultAccount.funds);
+  const sender = account;
 
+  const activeStep = useAtomValue(activeStepState);
   const handleExecute = async () => {
     try {
       const res = await sim.execute(
@@ -68,6 +71,8 @@ export default function Executor({ contractAddress }: IProps) {
             account={account}
             changeAccount={setAccount}
             accounts={accounts}
+            funds={funds}
+            changeFunds={setFunds}
           />
         </>
       }

--- a/src/components/simulation/Executor.tsx
+++ b/src/components/simulation/Executor.tsx
@@ -9,6 +9,7 @@ import { useAccounts } from "../../CWSimulationBridge";
 import { activeStepState } from "../../atoms/simulationPageAtoms";
 import { BeautifyJSON } from "./tabs/Common";
 import CollapsibleWidget from "../CollapsibleWidget";
+import AccountPopover from "./AccountPopover";
 
 interface IProps {
   contractAddress: string;
@@ -26,8 +27,10 @@ export default function Executor({ contractAddress }: IProps) {
   const setNotification = useNotification();
   const [payload, setPayload] = useState("");
   const [isValid, setIsValid] = useState(true);
-  // TODO: customize sender & funds
-  const [sender, funds] = Object.entries(useAccounts(sim))[0] ?? [];
+  const accounts = useAccounts(sim);
+  const [account, setAccount] = useState(Object.keys(accounts)[0]);
+  const [sender, funds] =
+    Object.entries(accounts).filter((itr) => itr[0] === account)[0] ?? [];
   const activeStep = useAtomValue(activeStepState);
 
   const handleExecute = async () => {
@@ -56,10 +59,17 @@ export default function Executor({ contractAddress }: IProps) {
       title={"Execute"}
       height={280}
       right={
-        <BeautifyJSON
-          onChange={setPayload}
-          disabled={!payload.length || !isValid}
-        />
+        <>
+          <BeautifyJSON
+            onChange={setPayload}
+            disabled={!payload.length || !isValid}
+          />
+          <AccountPopover
+            account={account}
+            changeAccount={setAccount}
+            accounts={accounts}
+          />
+        </>
       }
     >
       <Grid

--- a/src/utils/commonUtils.ts
+++ b/src/utils/commonUtils.ts
@@ -1,4 +1,5 @@
 import { TraceLog } from "@terran-one/cw-simulate";
+import { defaults } from '../configs/constants';
 
 export const getStepTrace = (activeStep: string, trace: TraceLog[]) => {
   const activeStepArr = activeStep.split("-").map((ele) => Number(ele));
@@ -10,3 +11,7 @@ export const getStepTrace = (activeStep: string, trace: TraceLog[]) => {
   }
   return activeTrace;
 };
+
+export const getDefaultAccount = (chainId: string) =>
+  Object.values(defaults.chains).find((config) => config.chainId === chainId) ??
+  defaults.chains.terra;


### PR DESCRIPTION
## Issue link

[[WL-XXX](https://terran-one.atlassian.net/browse/WL-XXX)
](https://trello.com/c/s47Vv2Th/96-fix-execute-funds-sender)

## Description
Now user can switch account from simulation screen by clicking on account icon in collapsible execute header. ( Initial version)

## Test steps

1. Go to simulation screen.
2. Perform some executions with default account, now go to accounts page and add one more account.
3. After adding account in accounts, go to simulation page again and click on account icon in collapsible execution header.
4. Now you have a popover with dropdown, from where you can select account and then perform the execution with that particular account.
