### PR TITLE
Not querying when payload is empty.

### DIFF
--- a/src/components/simulation/tabs/QueryTab.tsx
+++ b/src/components/simulation/tabs/QueryTab.tsx
@@ -86,7 +86,7 @@ function Query({ contractAddress, onHandleQuery }: IQuery) {
   };
 
   useEffect(() => {
-    handleQuery();
+    if (payload) handleQuery();
   }, [activeStep]);
   useEffect(() => {
     setPayload("");


### PR DESCRIPTION
## Issue link

Quick Fix

## Description
Query was being called even payload was empty, so just added a check.

## Test steps

1. Go to simulation page, and just navigate to query, snackbar shouldn't pop up with error.
2. Now perform some executions, and query on some step, it should work as expected.
