### PR TITLE
Close Drawer upon instantiating or switching contract

### DIFF
--- a/src/atoms/uiState.ts
+++ b/src/atoms/uiState.ts
@@ -1,3 +1,6 @@
+import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import type { SubMenu } from "src/components/drawer/T1Drawer";
 
 export const darkModeState = atomWithStorage('darkmode', false);
+export const drawerSubMenuState = atom<SubMenu | undefined>(undefined);

--- a/src/components/drawer/ContractsSubMenu.tsx
+++ b/src/components/drawer/ContractsSubMenu.tsx
@@ -18,9 +18,11 @@ import {
   Typography,
 } from "@mui/material";
 import type { CodeInfo, Coin } from "@terran-one/cw-simulate";
+import { useSetAtom } from "jotai";
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useNotification } from "../../atoms/snackbarNotificationState";
+import { drawerSubMenuState } from "../../atoms/uiState";
 import T1Container from "../grid/T1Container";
 import { JsonCodeMirrorEditor } from "../JsonCodeMirrorEditor";
 import UploadModal from "../upload/UploadModal";
@@ -180,6 +182,7 @@ function InstantiateDialog(props: IInstantiateDialogProps) {
   const sim = useSimulation();
   const navigate = useNavigate();
   const setNotification = useNotification();
+  const setDrawerSubMenu = useSetAtom(drawerSubMenuState);
   const [funds, setFunds] = useState<Coin[]>([]);
   const [isFundsValid, setFundsValid] = useState(true);
   const [payload, setPayload] = useState("");
@@ -211,6 +214,7 @@ function InstantiateDialog(props: IInstantiateDialogProps) {
       );
       navigate(`/instances/${contract.address}`);
       onClose();
+      setDrawerSubMenu(undefined);
     } catch (e: any) {
       setNotification(`Unable to instantiate with error: ${e.message}`, {
         severity: "error",
@@ -250,7 +254,7 @@ function InstantiateDialog(props: IInstantiateDialogProps) {
         </T1Container>
       </DialogContent>
       <DialogActions>
-        <Button variant="outlined" onClick={() => onClose()}>
+        <Button variant="outlined" onClick={onClose}>
           Cancel
         </Button>
         <Button

--- a/src/components/drawer/InstancesSubMenu.tsx
+++ b/src/components/drawer/InstancesSubMenu.tsx
@@ -8,10 +8,12 @@ import { ContractInfo } from "@terran-one/cw-simulate";
 import copy from "copy-to-clipboard";
 import { useNavigate } from "react-router-dom";
 import { useNotification } from "../../atoms/snackbarNotificationState";
+import { drawerSubMenuState } from "../../atoms/uiState";
 import { useContracts, compareDeep } from "../../CWSimulationBridge";
 import useSimulation from "../../hooks/useSimulation";
 import SubMenuHeader from "./SubMenuHeader";
 import T1MenuItem from "./T1MenuItem";
+import { useSetAtom } from "jotai";
 
 export interface IInstancesSubMenuProps {}
 
@@ -40,6 +42,7 @@ function InstanceMenuItem({ instance }: IInstanceMenuItemProps) {
   const sim = useSimulation();
   const navigate = useNavigate();
   const setNotification = useNotification();
+  const setDrawerSubMenu = useSetAtom(drawerSubMenuState);
   
   const code = sim.useWatcher(
     ({ wasm }) => {
@@ -60,6 +63,7 @@ function InstanceMenuItem({ instance }: IInstanceMenuItemProps) {
       label={instance.address}
       textEllipsis
       link={`/instances/${instance.address}`}
+      onClick={() => {setDrawerSubMenu(undefined)}}
       tooltip={
         <>
           {code

--- a/src/components/drawer/T1Drawer.tsx
+++ b/src/components/drawer/T1Drawer.tsx
@@ -10,14 +10,16 @@ import IconButton from "@mui/material/IconButton";
 import Paper from "@mui/material/Paper";
 import Slide from "@mui/material/Slide";
 import Tooltip from "@mui/material/Tooltip";
+import { useAtom } from "jotai";
 import React, { MouseEvent, ReactNode, useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { drawerSubMenuState } from "../../atoms/uiState";
 import { useTheme } from "../../configs/theme";
 import ContractsSubMenu from "./ContractsSubMenu";
 import InstancesSubMenu from "./InstancesSubMenu";
 import SettingsSubMenu from "./SettingsSubMenu";
 
-type SubMenu = 'contracts' | 'instances' | 'states' | 'accounts' | 'settings';
+export type SubMenu = 'contracts' | 'instances' | 'states' | 'accounts' | 'settings';
 
 export interface IT1Drawer {
   barWidth?: number;
@@ -31,7 +33,7 @@ const T1Drawer = (props: IT1Drawer) => {
   } = props;
 
   const navigate = useNavigate();
-  const [menu, setMenu] = useState<SubMenu | undefined>(undefined);
+  const [menu, setMenu] = useAtom(drawerSubMenuState);
 
   return (
     <ClickAwayListener onClickAway={() => setMenu(undefined)}>


### PR DESCRIPTION
## Description
Upon user feedback: automatically close drawer after instantiating or when switching contracts.

## Test steps
1. Create simulation
2. Instantiate contract. Drawer should automatically close upon success.
3. Open instances drawer & click instance. Drawer should again automatically close.
