### PR TITLE
Added copy output JSON functionality to State and Query responses.

### DIFF
--- a/src/components/T1JsonTree.tsx
+++ b/src/components/T1JsonTree.tsx
@@ -1,5 +1,5 @@
-import { Box } from "@mui/material";
-import React from "react";
+import { Grid } from "@mui/material";
+import React, { ReactNode } from "react";
 import { JSONTree } from "react-json-tree";
 import { useTheme } from "../configs/theme";
 
@@ -26,26 +26,38 @@ const theme = {
 
 export interface IT1JsonTreeProps {
   data: any;
+  right?: ReactNode;
 }
 
-const T1JsonTree = React.memo(({data}: IT1JsonTreeProps) => {
+const T1JsonTree = React.memo(({ data, right }: IT1JsonTreeProps) => {
   const muiTheme = useTheme();
 
   return (
-    <Box sx={{
-      '& > *': {
-        background: 'transparent !important',
-      },
-      fontFamily: 'JetBrains Mono'
-    }}>
-      <JSONTree
-        data={data}
-        theme={theme}
-        invertTheme={muiTheme.palette.mode === 'dark'}
-        shouldExpandNode={() => true}
-      />
-    </Box>
-  )
+    <Grid
+      container
+      sx={{
+        fontFamily: "JetBrains Mono",
+      }}
+    >
+      <Grid
+        item
+        flex={1}
+        sx={{
+          "& > *": {
+            background: "transparent !important",
+          },
+        }}
+      >
+        <JSONTree
+          data={data}
+          theme={theme}
+          invertTheme={muiTheme.palette.mode === "dark"}
+          shouldExpandNode={() => true}
+        />
+      </Grid>
+      <Grid item>{right}</Grid>
+    </Grid>
+  );
 });
 
 export default T1JsonTree;

--- a/src/components/simulation/tabs/QueryTab.tsx
+++ b/src/components/simulation/tabs/QueryTab.tsx
@@ -13,6 +13,7 @@ import { getFormattedStep } from "../Executor";
 import { Result } from "ts-results/result";
 import { BeautifyJSON, EmptyTab, TabHeader } from "./Common";
 import BlockQuote from "../../BlockQuote";
+import CopyToClipBoard from "../CopyToClipBoard";
 
 interface IProps {
   contractAddress: string;
@@ -45,7 +46,15 @@ export default function QueryTab({ contractAddress }: IProps) {
               <BlockQuote>{response.val}</BlockQuote>
             </>
           ) : response ? (
-            <T1JsonTree data={response?.val} />
+            <T1JsonTree
+              data={response?.val}
+              right={
+                <CopyToClipBoard
+                  data={JSON.stringify(response?.val)}
+                  title="Copy Query Response"
+                />
+              }
+            />
           ) : (
             <EmptyTab>Your query output will appear here</EmptyTab>
           )}

--- a/src/components/simulation/tabs/StateTab.tsx
+++ b/src/components/simulation/tabs/StateTab.tsx
@@ -11,6 +11,7 @@ import {
 import T1JsonTree from "../../T1JsonTree";
 import { EmptyTab } from "./Common";
 import { darkModeState } from "../../../atoms/uiState";
+import CopyToClipBoard from "../CopyToClipBoard";
 
 export interface IStateTabProps {}
 
@@ -35,6 +36,16 @@ export const StateTab = ({}: IStateTabProps) => {
     );
   } else {
     if (!currentJSON) return <EmptyTab />;
-    return <T1JsonTree data={currentJSON} />;
+    return (
+      <T1JsonTree
+        data={currentJSON}
+        right={
+          <CopyToClipBoard
+            data={JSON.stringify(currentJSON)}
+            title="Copy State Response"
+          />
+        }
+      />
+    );
   }
 };


### PR DESCRIPTION
## Issue link

[[WL-XXX](https://terran-one.atlassian.net/browse/WL-XXX)](https://trello.com/c/2xEVOoJq/110-add-copy-button-next-to-state-and-query-output-as-well)

## Description
Added copy JSON functionality to State and Query tab responses.

## Test steps

1. Go to simulation page.
2. Perform some executions, now in State tab you can see copy button on top-right corner and same goes for query as well.
