### PR TITLE
Show funds set in Account Popover.

### DIFF
--- a/src/components/Funds.tsx
+++ b/src/components/Funds.tsx
@@ -4,7 +4,13 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { SxProps } from "@mui/system/styleFunctionSx";
 import { Coin } from "@terran-one/cw-simulate";
-import { ComponentType, PropsWithChildren, ReactNode, useRef, useState } from "react";
+import {
+  ComponentType,
+  PropsWithChildren,
+  ReactNode,
+  useRef,
+  useState,
+} from "react";
 import useDebounce from "../hooks/useDebounce";
 
 export interface IFundsProps {
@@ -27,25 +33,31 @@ export default function Funds(props: IFundsProps) {
     onValidate,
     ...boxProps
   } = props;
-  
+
   const ref = useRef<HTMLInputElement | null>();
-  const [err, setErr] = useState('');
-  
-  const update = useDebounce(() => {
-    const value = ref.current?.value.trim() ?? '';
-    
-    try {
-      if (value) {
-        onChange?.(parseCoins(value));
+  const [err, setErr] = useState("");
+
+  const update = useDebounce(
+    () => {
+      const value = ref.current?.value.trim() ?? "";
+
+      try {
+        if (value) {
+          onChange?.(parseCoins(value));
+        } else {
+          onChange?.([]);
+        }
+        onValidate?.(true);
+        setErr("");
+      } catch (err: any) {
+        setErr(err.message || "Failed to parse funds");
+        onValidate?.(false);
       }
-      onValidate?.(true);
-      setErr('');
-    } catch (err: any) {
-      setErr(err.message || 'Failed to parse funds');
-      onValidate?.(false);
-    }
-  }, 500, [onChange, onValidate]);
-  
+    },
+    500,
+    [onChange, onValidate]
+  );
+
   return (
     <Box {...boxProps}>
       {text}
@@ -54,27 +66,28 @@ export default function Funds(props: IFundsProps) {
         label="Funds"
         onKeyUp={update}
         defaultValue={defaultValue}
-        placeholder={'1000 uluna, 4000 uust, ...'}
-        sx={{width: '100%'}}
+        placeholder={"1000 uluna, 4000 uust, ..."}
+        sx={{ width: "100%" }}
       />
       {!hideError && err && (
-        <TextComponent fontStyle="italic" color="red">{err}</TextComponent>
+        <TextComponent fontStyle="italic" color="red">
+          {err}
+        </TextComponent>
       )}
     </Box>
-  )
+  );
 }
 
 const parseCoins = (raw: string): Coin[] =>
   raw
-  .split(',')
-  .map(s => s.trim())
-  .map(line => {
-    const matches = line.match(/^([0-9]+)\s?([A-Za-z]+)$/);
-    if (!matches)
-      throw new Error(`Invalid coin format: ${line}`);
+    .split(",")
+    .map((s) => s.trim())
+    .map((line) => {
+      const matches = line.match(/^([0-9]+)\s?([A-Za-z]+)$/);
+      if (!matches) throw new Error(`Invalid coin format: ${line}`);
 
-    return {
-      denom: matches[2],
-      amount: matches[1],
-    }
-  });
+      return {
+        denom: matches[2],
+        amount: matches[1],
+      };
+    });

--- a/src/components/simulation/AccountPopover.tsx
+++ b/src/components/simulation/AccountPopover.tsx
@@ -9,18 +9,22 @@ import {
 } from "@mui/material";
 import { Coin } from "@terran-one/cw-simulate";
 import Funds from "../Funds";
+import { stringifyFunds } from "../../utils/typeUtils";
 
 interface IProps {
   accounts: { [key: string]: Coin[] };
   changeAccount: (val: string) => void;
-
   changeFunds?(funds: Coin[]): void;
+  account: string;
+  funds: Coin[];
 }
 
 const AccountPopover = ({
   changeAccount,
   accounts,
   changeFunds,
+  account,
+  funds,
 }: IProps) => {
   const [anchorEl, setAnchorEl] =
     React.useState<HTMLButtonElement | null>(null);
@@ -37,7 +41,7 @@ const AccountPopover = ({
   return (
     <>
       <Button aria-describedby="abcd" onClick={handleDiffClick}>
-        <AccountBalanceWalletOutlinedIcon sx={{color: "white"}}/>
+        <AccountBalanceWalletOutlinedIcon sx={{ color: "white" }} />
       </Button>
       <Popover
         id={id}
@@ -61,16 +65,18 @@ const AccountPopover = ({
       >
         <Autocomplete
           onInputChange={(_, value) => changeAccount(value)}
-          sx={{width: "100%"}}
+          value={account}
+          sx={{ width: "100%" }}
           renderInput={(params: AutocompleteRenderInputParams) => (
-            <TextField {...params} label="Sender"/>
+            <TextField {...params} label="Sender" />
           )}
           options={Object.keys(accounts)}
         />
         <Funds
+          defaultValue={stringifyFunds(funds)}
           onChange={changeFunds}
           onValidate={setFundsValid}
-          sx={{mt: 2}}
+          sx={{ mt: 2 }}
         />
       </Popover>
     </>

--- a/src/components/simulation/Executor.tsx
+++ b/src/components/simulation/Executor.tsx
@@ -10,7 +10,6 @@ import { activeStepState } from "../../atoms/simulationPageAtoms";
 import { BeautifyJSON } from "./tabs/Common";
 import CollapsibleWidget from "../CollapsibleWidget";
 import AccountPopover from "./AccountPopover";
-import { getDefaultAccount } from "../../utils/commonUtils";
 import { Coin } from "@terran-one/cw-simulate/dist/types";
 
 interface IProps {
@@ -20,20 +19,19 @@ interface IProps {
 export const getFormattedStep = (step: string) => {
   const activeStepArr = step.split("-").map((ele) => Number(ele) + 1);
   let formattedStep = activeStepArr
-  .slice(0, activeStepArr.length - 1)
-  .join(".");
+    .slice(0, activeStepArr.length - 1)
+    .join(".");
   return formattedStep;
 };
 
-export default function Executor({contractAddress}: IProps) {
+export default function Executor({ contractAddress }: IProps) {
   const sim = useSimulation();
   const setNotification = useNotification();
-  const defaultAccount = getDefaultAccount(sim.chainId);
   const [payload, setPayload] = useState("");
   const [isValid, setIsValid] = useState(true);
   const accounts = useAccounts(sim);
   const [account, setAccount] = useState(Object.keys(accounts)[0]);
-  const [funds, setFunds] = useState<Coin[]>(defaultAccount.funds);
+  const [funds, setFunds] = useState<Coin[]>([]);
   const sender = account;
 
   const activeStep = useAtomValue(activeStepState);
@@ -71,6 +69,8 @@ export default function Executor({contractAddress}: IProps) {
           <AccountPopover
             changeAccount={setAccount}
             accounts={accounts}
+            account={account}
+            funds={funds}
             changeFunds={setFunds}
           />
         </>


### PR DESCRIPTION
## Issue link

(https://terran-one.atlassian.net/browse/WL-XXX)](https://trello.com/c/buHhalGy/115-accounts-popover-not-remembering-current-values)

## Description
The account popover now shows funds and sender value persisted in useState hook.

## Test steps

1. Go to simulation page.
2. Go to account popover, now you will see sender with value but funds with no value.
3. Set some value of funds and now execute, check the response.
4. Now go to account popover again it should show funds which were previously, clear funds and again execute then check response. Now go to popover again, there should be no funds.
