### PR TITLE
Fix/session restore

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,63 @@
 import { Grid } from "@mui/material";
-import { Route, Routes, useLocation, useNavigate, useNavigation } from "react-router-dom";
+import { useSetAtom } from "jotai";
+import { useEffect, useRef, useState } from "react";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
+import { lastChainIdState } from "./atoms/simulationPageAtoms";
+import { useNotification } from "./atoms/snackbarNotificationState";
 import Accounts from "./components/chains/Accounts";
 import T1AppBar from "./components/drawer/T1AppBar";
-import VoidScreen from "./components/screens/VoidScreen";
+import T1Container from "./components/grid/T1Container";
+import LoadingScreen from "./components/screens/LoadingScreen";
 import SimulationScreen from "./components/screens/SimulationScreen";
+import VoidScreen from "./components/screens/VoidScreen";
 import WelcomeScreen from "./components/screens/WelcomeScreen";
 import Simulation from "./components/simulation/Simulation";
-import T1Container from "./components/grid/T1Container";
+import { useSession } from "./hooks/useSession";
+import useSimulation from "./hooks/useSimulation";
 import "./index.css";
-import { useAtomValue } from "jotai";
-import { lastChainIdState } from "./atoms/simulationPageAtoms";
-import { useEffect, useRef } from "react";
 
 function App() {
-  const lastChainId = useAtomValue(lastChainIdState);
-  const refInitial = useRef(true);
+  const bridge = useSimulation();
+  const session = useSession();
+  const setNotification = useNotification();
   const loc = useLocation();
   const navigate = useNavigate();
+  const setLastChainId = useSetAtom(lastChainIdState);
+  
+  const refInitial = useRef(true);
+  const [isLoading, setLoading] = useState(true);
   
   useEffect(() => {
-    if (refInitial.current) {
-      refInitial.current = false;
-      if (lastChainId) {
-        if (loc.pathname === '/') navigate('/accounts');
-      } else {
-        if (loc.pathname !== '/') navigate('/');
+    // only attempt to restore an old session once
+    if (session && refInitial.current) {
+      const lastChainId = localStorage['lastChainId'];
+      
+      // only attempt to restore an old session if we have a lastChainId stored upon loadup
+      if (!lastChainId) {
+        navigate('/');
+        refInitial.current = false;
+        setLoading(false);
+        return;
       }
+      
+      session.load(bridge, lastChainId)
+        .then(() => {
+          setNotification('Previous session restored');
+          setLastChainId(lastChainId);
+          loc.pathname === '/' && navigate('/accounts');
+        })
+        .catch(() => {
+          setNotification('Failed to restore previous session', { severity: 'error' });
+          loc.pathname !== '/' && navigate('/');
+        })
+        .finally(() => {
+          refInitial.current = false;
+          setLoading(false);
+        })
     }
-  }, []);
+  }, [session]);
   
+  if (isLoading) return <LoadingScreen />
   return (
     <Grid container direction="column" width="100vw" height="100vh" className="T1App-root">
       <T1AppBar/>

--- a/src/atoms/simulationPageAtoms.ts
+++ b/src/atoms/simulationPageAtoms.ts
@@ -17,7 +17,7 @@ export interface IRequest {
   executeMsg: any;
 }
 
-export const lastChainIdState = atomWithStorage('lastChainId', '');
+export const lastChainIdState = atom('');
 export const blockState = atom<JSON | undefined>(undefined);
 export const compareStates = atom<{ state1: object | undefined; state2: object | undefined }>({
   state1: undefined,

--- a/src/components/drawer/SettingsSubMenu.tsx
+++ b/src/components/drawer/SettingsSubMenu.tsx
@@ -45,12 +45,13 @@ export default function SettingsSubMenu(props: ISettingsSubMenuProps) {
     await session?.clear(sim.chainId);
     sim.recreate(defaults.chains.terra);
     setLastChainId('');
+    delete localStorage['lastChainId'];
     
     // UI cleanup
     setOpenResetSimulationDialog(false);
     navigate('/');
     
-    setNotification('Session successfully reset. You will need a new account.');
+    setNotification('Session has been reset.');
   };
   setStepTrace(undefined);
 

--- a/src/components/drawer/T1AppBar.tsx
+++ b/src/components/drawer/T1AppBar.tsx
@@ -39,14 +39,14 @@ const T1AppBar = React.memo((props: IT1AppBarProps) => {
     setNotification('Saving session to IndexedDB, this might take a while...', { severity: 'info' });
     setTimeout(async () => {
       try {
-        session?.save(sim);
+        session?.save(sim, lastChainId);
         setNotification('Session saved to IndexedDB.', { severity: 'success' });
       } catch (err: any) {
         console.error('Failed to save session:', err);
         setNotification(`Failed to save session to IndexedDB: ${err.message}`);
       }
     }, 500);
-  }, [sim, session]);
+  }, [lastChainId, sim, session]);
   
   return (
     <AppBar position="static">

--- a/src/components/screens/LoadingScreen.tsx
+++ b/src/components/screens/LoadingScreen.tsx
@@ -1,0 +1,39 @@
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import { useTheme } from '../../configs/theme';
+
+export default function LoadingScreen() {
+  const theme = useTheme();
+  
+  return (
+    <Box sx={{
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+      position: 'absolute',
+      gap: 1,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+    }}>
+      <Typography
+        component='h2'
+        variant='h2'
+        color={theme.palette.primary.main}
+      >
+        Loading
+      </Typography>
+      <Typography variant='subtitle1'>Attempting to restore previous session...</Typography>
+      <CircularProgress
+        disableShrink
+        thickness={4}
+        sx={{
+          animationDuration: '550ms',
+        }}
+      />
+    </Box>
+  )
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -39,7 +39,8 @@ export class Session {
     this._idb?.close();
   }
   
-  save(sim: CWSimulationBridge) {
+  save(sim: CWSimulationBridge, lastChainId: string) {
+    localStorage['lastChainId'] = lastChainId;
     return this.tx('chains', 'readwrite', async tx => {
       const chainsStore = tx.objectStore('chains');
       await wrapRequest(chainsStore.put(sim.save(), sim.chainId));

--- a/src/hooks/useSimulation.tsx
+++ b/src/hooks/useSimulation.tsx
@@ -9,71 +9,10 @@ const SimulationContext = React.createContext(new CWSimulationBridge());
 
 export interface ICWSimulationProviderProps {
   children?: ReactNode;
-  /** Optional persistence key for localStorage */
-  persist?: string;
-  /** Interval in ms in which to save session */
-  saveInterval?: number;
 }
 
-export function CWSimulationProvider({ children, persist, saveInterval = 600000 }: ICWSimulationProviderProps) {
+export function CWSimulationProvider({ children }: ICWSimulationProviderProps) {
   const bridge = useRef(new CWSimulationBridge());
-  const setNotification = useNotification();
-  const lastChainId = useAtomValue(lastChainIdState);
-  const session = useSession();
-  
-  useEffect(() => {
-    if (!persist || !session || !lastChainId) return;
-    if (!window.indexedDB) {
-      setNotification(
-        'Your browser does not support IndexedDB. Session cannot be persisted.',
-        {
-          severity: 'warning',
-          autoHideDuration: 20000,
-        },
-      );
-      return;
-    }
-    
-    lastChainId && setNotification('Attempting to restore existing session...', { severity: 'info' });
-    
-    session.load(bridge.current, lastChainId)
-      .then(() => {
-        setNotification('Last session successfully restored');
-      })
-      .catch(err => {
-        if (err instanceof BlockedError) {
-          setNotification(`IndexedDB connection blocked. Please close other CWSimulate tabs.`, { severity: 'error' });
-        } else {
-          setNotification(`Failed to establish IndexedDB connection: ${err?.message ?? 'unknown error'}`, { severity: 'error' });
-        }
-      });
-  }, [session]);
-  
-  // TODO: Session currently takes quite long to save as we're re-serializing unchanged data every single time
-  // which includes wasm bytecode in the order of millions of bytes
-  // we should identify which parts of the data store have been changed and only re-serialize those, which will avoid
-  // re-serializing several MB of binary data
-  // once we have that back we can re-enable auto-saving
-  
-  // useEffect(() => {
-  //   if (!persist || !session || !lastChainId || !window.indexedDB) return;
-  //   let isAlive = true;
-  //   let timeout: ReturnType<typeof setTimeout> | undefined;
-    
-  //   const save = async () => {
-  //     setNotification('Autosaving, app may be unresponsive...', { severity: 'info' });
-  //     await session?.save(bridge.current);
-  //     setNotification('Autosave complete');
-  //     if (isAlive) timeout = setTimeout(save, saveInterval);
-  //   }
-  //   timeout = setTimeout(save, saveInterval);
-    
-  //   return () => {
-  //     isAlive = false;
-  //     clearTimeout(timeout);
-  //     session?.save(bridge.current);
-  //   }
-  // }, [session, lastChainId]);
   
   return (
     <SimulationContext.Provider value={bridge.current}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ function Root() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <SnackbarNotification/>
-      <CWSimulationProvider persist="cw-simulate">
+      <CWSimulationProvider>
         <App/>
       </CWSimulationProvider>
     </ThemeProvider>


### PR DESCRIPTION
## Issue link
https://trello.com/c/CkD01Uq0/140-redirect-to-welcome-screen-when-no-prior-session-data-found
https://trello.com/c/uhuuvSpg/139-fix-no-chainid-found-issue

## Description
Fixes session restoration failure handling:

- Improves session loading algorithm
- Fixes app behaving oddly when it fails to restore a session
- Introduce new intermittent Loading Screen while the app attempts to restore previous session

## Test steps
1. Create a new session & save
2. Refresh page
3. LoadingScreen should show (even if briefly)
4. Reset simulation. You should now be on the WelcomeScreen
5. Refresh page
6. It should not attempt to load a non-existent session & remain on the WelcomeScreen
