### PR TITLE
Confirm closing Instantiate dialog

### DIFF
--- a/src/components/DialogButton.tsx
+++ b/src/components/DialogButton.tsx
@@ -1,0 +1,63 @@
+import { cx } from '@emotion/css';
+import Button from '@mui/material/Button';
+import Portal from '@mui/material/Portal';
+import { ComponentType, MouseEvent, ReactNode, useCallback, useState } from 'react';
+import { StyleProps } from 'src/utils/typeUtils';
+
+export type DialogButtonProps = StyleProps & {
+  children?: ReactNode;
+  Component?: ComponentType<{
+    children?: ReactNode;
+    onClick?(e: MouseEvent): void;
+  }>;
+  DialogComponent: ComponentType<{
+    open?: boolean;
+    onClose(): void;
+  }>;
+  onClick?(e: MouseEvent): void;
+  onClose?(): void;
+}
+
+/** A specialized button for showing dialogs upon click. */
+export default function DialogButton({
+  children,
+  Component = Button,
+  DialogComponent,
+  onClick,
+  onClose,
+  sx,
+  className,
+}: DialogButtonProps) {
+  const [open, setOpen] = useState(false);
+  
+  const close = useCallback(() => {
+    setOpen(false);
+    onClose?.();
+  }, [onClose]);
+  
+  const handleClick = useCallback((e: MouseEvent) => {
+    setOpen(true);
+    onClick?.(e);
+  }, [onClick]);
+  
+  return (
+    <>
+      <Component
+        onClick={handleClick}
+        // ignore these two props, they're optional
+        //@ts-ignore
+        sx={sx}
+        //@ts-ignore
+        className={cx('T1DialogButton', className)}
+      >
+        {children}
+      </Component>
+      <Portal>
+        <DialogComponent
+          open={open}
+          onClose={close}
+        />
+      </Portal>
+    </>
+  )
+}

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -45,11 +45,3 @@ export default function Options({
     </>
   );
 }
-
-export interface IOptionsItemProps {
-  children?: ReactNode;
-}
-
-export function OptionsItem({ children }: IOptionsProps) {
-  
-}

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,81 @@
+import { cx } from '@emotion/css';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import { ReactNode } from 'react';
+import { StyleProps } from '../../utils/typeUtils'
+
+export type ConfirmDialogProps = StyleProps & {
+  children?: ReactNode;
+  title?: string;
+  message?: string;
+  open?: boolean;
+  onConfirm?(): void;
+  onCancel?(): void;
+  onClose?(): void;
+}
+
+export default function ConfirmDialog({
+  children,
+  open = false,
+  title = 'Please confirm',
+  message = 'Are you certain you want to continue? This has potentially unstable, dangerous, or irrecoverable implications.',
+  onConfirm,
+  onCancel,
+  onClose,
+  sx,
+  className,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      sx={sx}
+      className={cx('T1ConfirmDialog', className)}
+    >
+      <DialogTitle>
+        {title}
+      </DialogTitle>
+      <DialogContent>
+        {children ?? (
+          <DialogContentText>{message}</DialogContentText>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            onCancel?.();
+            onClose?.();
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            onConfirm?.();
+            onClose?.();
+          }}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export type ConfirmDeleteDialogProps = ConfirmDialogProps & {
+  noun?: string;
+}
+
+/** A `ConfirmDialog` with different defaults suitable for deletion confirmation dialogs. */
+export function ConfirmDeleteDialog({ noun, ...props }: ConfirmDeleteDialogProps) {
+  return (
+    <ConfirmDialog
+      {...props}
+      title='Confirm Deletion'
+      message={`Are you sure you want to delete this${noun ? ` ${noun}` : ''}?`}
+    />
+  )
+}

--- a/src/components/dialogs/T1Dialog.tsx
+++ b/src/components/dialogs/T1Dialog.tsx
@@ -1,0 +1,75 @@
+import { cx } from '@emotion/css';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import { ComponentType, ReactNode, useCallback, useMemo, useState } from 'react';
+import type { StyleProps } from '../../utils/typeUtils';
+import ConfirmDialog from './ConfirmDialog';
+
+export type T1DialogProps = StyleProps & {
+  children?: ReactNode;
+  open?: boolean;
+  confirmClose?: boolean;
+  title?: string;
+  actions?: ReactNode | ((api: T1DialogAPI) => ReactNode);
+  ConfirmCloseDialogComponent?: ComponentType<{
+    open: boolean;
+    onConfirm(): void;
+    onClose(): void;
+  }>;
+  onClose(): void;
+}
+
+export interface T1DialogAPI {
+  /** Close the T1Dialog. If `success` is true, the action is considered successfully completed and the dialog is closed
+   * immediately. Otherwise, if `confirmClose` property is true, asks for confirmation before closing.
+   */
+  close(success: boolean): void;
+}
+
+export default function T1Dialog({
+  children,
+  open,
+  confirmClose,
+  title,
+  actions,
+  ConfirmCloseDialogComponent = ConfirmDialog,
+  onClose,
+  sx,
+  className,
+}: T1DialogProps) {
+  const [openConfirmClose, setOpenConfirmClose] = useState(false);
+  
+  const api = useMemo<T1DialogAPI>(() => ({
+    close(success) {
+      if (success || !confirmClose) {
+        onClose();
+      } else {
+        setOpenConfirmClose(true);
+      }
+    },
+  }), [confirmClose, onClose]);
+  
+  const handleConfirmClose = useCallback(() => {
+    setOpenConfirmClose(false);
+    onClose();
+  }, [onClose]);
+  
+  return (
+    <>
+      <Dialog open={!!open} onClose={() => api.close(false)} sx={sx} className={cx('T1Dialog', className)}>
+        <DialogTitle>{title}</DialogTitle>
+        {children}
+        <DialogActions>
+          {typeof actions === 'function' ? actions(api) : actions}
+        </DialogActions>
+      </Dialog>
+      <ConfirmCloseDialogComponent
+        open={openConfirmClose}
+        onConfirm={handleConfirmClose}
+        onClose={() => {setOpenConfirmClose(false)}}
+      />
+    </>
+  )
+}

--- a/src/components/drawer/T1MenuItem.tsx
+++ b/src/components/drawer/T1MenuItem.tsx
@@ -62,6 +62,9 @@ export default function T1MenuItem(props: IT1MenuItemProps) {
       setOptionsOpen(false);
     },
   }), []);
+  
+  const opts = useMemo(() => typeof options === 'function' ? options(api) : options, [options]);
+  const optsX = useMemo(() => typeof optionsExtras === 'function' ? optionsExtras(api) : optionsExtras, [optionsExtras]);
 
   return (
     <ListItem
@@ -90,9 +93,9 @@ export default function T1MenuItem(props: IT1MenuItemProps) {
               onOpen={() => setOptionsOpen(true)}
               onClose={() => setOptionsOpen(false)}
             >
-              {typeof options === 'function' ? options(api) : options}
+              {opts}
             </Options>
-            {typeof optionsExtras === 'function' ? optionsExtras(api) : optionsExtras}
+            {optsX}
           </Box>
         )
       }

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -28,6 +28,10 @@ type JSONifiable = {
 
 export type Theme = MuiTheme;
 export type SxProps = MuiSxProps<Theme>;
+export type StyleProps = {
+  sx?: SxProps;
+  className?: string;
+}
 
 type GridSizeName = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 


### PR DESCRIPTION
## Issue link
https://trello.com/c/Aeimb3PF/129-confirm-closing-when-instantiating

## Description
When instantiating a contract, it is too easy to accidentally close the dialog by clicking outside it. This should be prevented by confirming whether the user intended to close the dialog.

Comes with some additional abstractions for handling dialogs, namely:

- `T1Dialog` - abstraction on top of MUI Dialog w/ `confirmClose` support
- `DialogButton` - generic component for opening dialogs upon clicking it
- `ConfirmDialog` - generic dialog asking for confirmation; customize with `title` and `message` props

## Test steps
1. Create new simulation
2. Instantiate a contract, but cancel out w/o pressing Instantiate button
3. Should be prompted with a confirm dialog
4. Actually instantiate - confirm dialog should not show up this time
