### PR TITLE
Quick fix for avoiding same label account addition

### DIFF
--- a/src/components/chains/Accounts.tsx
+++ b/src/components/chains/Accounts.tsx
@@ -210,9 +210,13 @@ function AddAccountDialog({ open, onClose }: AddAccountDialogProps) {
     }
 
     // TODO: validate bech32
-
-    if (accounts.find(([addr]) => addr === account.address)) {
-      setNotification("An account with this address already exists", {
+    if (
+      accounts.find(
+        ([addr, { label }]) =>
+          addr === account.address || label === account.label
+      )
+    ) {
+      setNotification("An account with this address or label already exists", {
         severity: "error",
       });
       return;


### PR DESCRIPTION
## Issue link

[WL-XXX](https://trello.com/c/gnXAUnBt/161-cwsimulate-account-with-same-label)

## Description
Accounts with same label will not be added anymore.

## Test steps

1. After uploading a contract, go to accounts page.
2. Try adding account with LabelA, and now again try adding account with same label again, a snackbar with error will appear on top.
